### PR TITLE
Add cookie import, brand channel switching, and auth fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ src/routeTree.gen.ts
 # Rust / Tauri
 src-tauri/target/
 src-tauri/gen/
+
+# Auth lab / local debug output (may contain session metadata)
+scripts/auth-lab/last-run.json
+scripts/auth-lab/accounts_list_dump.json
+scripts/auth-lab/switcher_*.json
+scripts/auth-lab/__pycache__/

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "start": "pnpm tauri dev",
     "build": "vite build && tsc --noEmit",
     "preview": "vite preview",
     "tauri": "tauri",

--- a/scripts/auth-lab/auth_lab.py
+++ b/scripts/auth-lab/auth_lab.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+"""
+YTubic InnerTube auth lab — test cookie / header combinations without rebuilding the app.
+
+Usage:
+  python auth_lab.py ytubic              # load cookies from YTubic AppData
+  python auth_lab.py file cookies.txt    # load Netscape export
+  python auth_lab.py file cookies.txt --brand 123456789012345678901
+  python auth_lab.py ytubic --json out.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import ctypes.wintypes as wt
+import hashlib
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+ORIGIN = "https://music.youtube.com"
+DEFAULT_CLIENT_VERSION = "1.20260510.02.00"
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+DPAPI_ENTROPY = b"ytm-native/cookies.enc v1"
+YTBIC_APPDATA = Path.home() / "AppData" / "Roaming" / "com.github.ivasy.ytubic"
+
+
+class DATA_BLOB(ctypes.Structure):
+    _fields_ = [("cbData", wt.DWORD), ("pbData", ctypes.POINTER(ctypes.c_char))]
+
+
+def dpapi_decrypt(data: bytes) -> bytes:
+    CryptUnprotectData = ctypes.windll.crypt32.CryptUnprotectData
+    LocalFree = ctypes.windll.kernel32.LocalFree
+    in_blob = DATA_BLOB(
+        len(data),
+        ctypes.cast(ctypes.create_string_buffer(data), ctypes.POINTER(ctypes.c_char)),
+    )
+    ent_blob = DATA_BLOB(
+        len(DPAPI_ENTROPY),
+        ctypes.cast(
+            ctypes.create_string_buffer(DPAPI_ENTROPY), ctypes.POINTER(ctypes.c_char)
+        ),
+    )
+    out_blob = DATA_BLOB()
+    if not CryptUnprotectData(
+        ctypes.byref(in_blob), None, ctypes.byref(ent_blob), None, None, 0, ctypes.byref(out_blob)
+    ):
+        raise OSError("CryptUnprotectData failed — run as the same Windows user as YTubic")
+    buf = ctypes.string_at(out_blob.pbData, out_blob.cbData)
+    LocalFree(out_blob.pbData)
+    return buf
+
+
+@dataclass
+class CookieRow:
+    domain: str
+    name: str
+    value: str
+
+
+def parse_netscape(text: str) -> list[CookieRow]:
+    rows: list[CookieRow] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            if line.startswith("#HttpOnly_"):
+                line = line[len("#HttpOnly_") :]
+            else:
+                continue
+        parts = line.split("\t")
+        if len(parts) < 7:
+            continue
+        rows.append(CookieRow(domain=parts[0], name=parts[5], value=parts[6]))
+    if not rows:
+        raise ValueError("no cookies parsed — need Netscape format (tab-separated)")
+    return rows
+
+
+def load_ytubic_netscape() -> tuple[str, Path]:
+    index_path = YTBIC_APPDATA / "accounts.json"
+    if not index_path.exists():
+        raise FileNotFoundError(f"no accounts.json at {index_path}")
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    active = index.get("active")
+    if not active:
+        raise FileNotFoundError("YTubic has no active account — sign in or import first")
+    enc = YTBIC_APPDATA / "accounts" / active / "cookies.enc"
+    if not enc.exists():
+        raise FileNotFoundError(f"missing {enc}")
+    plain = dpapi_decrypt(enc.read_bytes()).decode("utf-8")
+    return plain, enc
+
+
+def domain_bare(domain: str) -> str:
+    return domain.lstrip(".")
+
+
+def filter_rows(rows: list[CookieRow], mode: str) -> list[CookieRow]:
+    out: list[CookieRow] = []
+    seen: set[tuple[str, str]] = set()
+    for r in rows:
+        bare = domain_bare(r.domain)
+        if mode == "youtube" and not bare.endswith("youtube.com"):
+            continue
+        if mode == "google" and not bare.endswith("google.com"):
+            continue
+        if mode == "all" and not (
+            bare.endswith("youtube.com") or bare.endswith("google.com")
+        ):
+            continue
+        key = (r.name, bare)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(r)
+    return out
+
+
+def cookie_header(rows: list[CookieRow]) -> str:
+    return "; ".join(f"{r.name}={r.value}" for r in rows)
+
+
+def pick_sapisid(rows: list[CookieRow], strategy: str) -> str | None:
+    yt_3p = yt_s = g_3p = g_s = None
+    for r in rows:
+        bare = domain_bare(r.domain)
+        if r.name == "__Secure-3PAPISID" and bare.endswith("youtube.com"):
+            yt_3p = r.value
+        elif r.name == "SAPISID" and bare.endswith("youtube.com"):
+            yt_s = r.value
+        elif r.name == "__Secure-3PAPISID" and bare.endswith("google.com"):
+            g_3p = r.value
+        elif r.name == "SAPISID" and bare.endswith("google.com"):
+            g_s = r.value
+    table = {
+        "yt-3papisid": yt_3p,
+        "yt-sapisid": yt_s,
+        "google-3papisid": g_3p,
+        "google-sapisid": g_s,
+        "flat-3p-then-s": yt_3p or g_3p or yt_s or g_s,
+        "google-sapisid-first": g_s or yt_s or g_3p or yt_3p,
+    }
+    return table.get(strategy)
+
+
+def sapisid_hash(sapisid: str, origin: str = ORIGIN) -> str:
+    ts = int(time.time())
+    digest = hashlib.sha1(f"{ts} {sapisid} {origin}".encode()).hexdigest()
+    return f"SAPISIDHASH {ts}_{digest}"
+
+
+def fetch_client_version() -> str:
+    try:
+        html = urllib.request.urlopen(ORIGIN, timeout=15).read().decode("utf-8", "replace")
+        for pat in (
+            r'INNERTUBE_CLIENT_VERSION":"([^"]+)"',
+            r'"INNERTUBE_CLIENT_VERSION":"([^"]+)"',
+        ):
+            m = re.search(pat, html)
+            if m:
+                return m.group(1)
+    except Exception:
+        pass
+    return DEFAULT_CLIENT_VERSION
+
+
+@dataclass
+class TestConfig:
+    label: str
+    cookie_mode: str = "all"
+    sapisid_strategy: str = "flat-3p-then-s"
+    authuser: str = "0"
+    brand_id: str | None = None
+    client_version: str | None = None
+    visitor_data: str | None = None
+    skip_auth: bool = False
+
+
+@dataclass
+class TestResult:
+    config: TestConfig
+    account_menu_status: int
+    account_signed_in: bool
+    account_name: str | None
+    browse_playlists_status: int
+    browse_has_library: bool
+    browse_error_snippet: str | None
+    accounts_list_status: int | None = None
+    channel_count: int = 0
+    channels: list[dict[str, Any]] = field(default_factory=list)
+    error: str | None = None
+
+
+def innertube_post(
+    cfg: TestConfig,
+    cookie: str,
+    authorization: str | None,
+    endpoint: str,
+    body: dict[str, Any],
+    client_version: str,
+) -> tuple[int, Any]:
+    user: dict[str, Any] = {"lockedSafetyMode": False}
+    if cfg.brand_id:
+        user["onBehalfOfUser"] = cfg.brand_id
+    client: dict[str, Any] = {
+        "clientName": "WEB_REMIX",
+        "clientVersion": client_version,
+        "hl": "en",
+        "gl": "US",
+        "platform": "DESKTOP",
+        "userAgent": f"{USER_AGENT},gzip(gfe)",
+        "originalUrl": f"{ORIGIN}/",
+    }
+    if cfg.visitor_data:
+        client["visitorData"] = cfg.visitor_data
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": USER_AGENT,
+        "X-YouTube-Client-Name": "67",
+        "X-YouTube-Client-Version": client_version,
+        "Origin": ORIGIN,
+        "Referer": f"{ORIGIN}/",
+        "X-Origin": ORIGIN,
+        "X-Goog-AuthUser": cfg.authuser,
+        "Cookie": cookie,
+    }
+    if authorization:
+        headers["Authorization"] = authorization
+    if cfg.visitor_data:
+        headers["X-Goog-Visitor-Id"] = cfg.visitor_data
+    payload = {"context": {"client": client, "user": user, "request": {"useSsl": True}}, **body}
+    req = urllib.request.Request(
+        f"{ORIGIN}/youtubei/v1/{endpoint}?prettyPrint=false",
+        data=json.dumps(payload).encode(),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", errors="replace")[:600]
+
+
+def parse_account_menu(payload: dict) -> tuple[bool, str | None]:
+    header = (
+        payload.get("actions", [{}])[0]
+        .get("openPopupAction", {})
+        .get("popup", {})
+        .get("multiPageMenuRenderer", {})
+        .get("header", {})
+        .get("activeAccountHeaderRenderer")
+    )
+    if not header:
+        return False, None
+    name = header.get("accountName", {})
+    text = name.get("simpleText")
+    if not text and isinstance(name.get("runs"), list):
+        text = "".join(r.get("text", "") for r in name["runs"])
+    return True, text
+
+
+def parse_browse_library(payload: dict | str) -> tuple[bool, str | None]:
+    if isinstance(payload, str):
+        return False, payload
+    blob = json.dumps(payload).lower()
+    if "sign in" in blob and "liked" not in blob:
+        return False, "sign-in prompt in response"
+    tabs = (
+        payload.get("contents", {})
+        .get("singleColumnBrowseResultsRenderer", {})
+        .get("tabs", [])
+    )
+    if tabs:
+        sections = (
+            tabs[0]
+            .get("tabRenderer", {})
+            .get("content", {})
+            .get("sectionListRenderer", {})
+            .get("contents", [])
+        )
+        if sections:
+            return True, None
+    return False, "no library sections in response"
+
+
+def collect_channels(payload: dict | str) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+    channels: list[dict[str, Any]] = []
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            if "accountName" in node:
+                name_runs = node.get("accountName", {})
+                name = name_runs.get("simpleText")
+                if not name and isinstance(name_runs.get("runs"), list):
+                    name = "".join(r.get("text", "") for r in name_runs["runs"])
+                handle_runs = node.get("channelHandle", {})
+                handle = handle_runs.get("simpleText")
+                if not handle and isinstance(handle_runs.get("runs"), list):
+                    handle = "".join(r.get("text", "") for r in handle_runs["runs"])
+                brand_id = extract_brand_id(node)
+                if name:
+                    channels.append(
+                        {
+                            "name": name,
+                            "handle": handle,
+                            "brandId": brand_id,
+                            "isSelected": bool(node.get("isSelected")),
+                        }
+                    )
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(payload)
+    dedup: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for ch in channels:
+        key = f"{ch.get('brandId') or 'primary'}:{ch['name']}"
+        if key in seen:
+            continue
+        seen.add(key)
+        dedup.append(ch)
+    return dedup
+
+
+def extract_brand_id(node: dict) -> str | None:
+    endpoint = node.get("serviceEndpoint") or node.get("endpoint")
+    if not isinstance(endpoint, dict):
+        return None
+    select = endpoint.get("selectActiveIdentityEndpoint")
+    if not isinstance(select, dict):
+        return None
+    tokens = select.get("supportedTokens") or []
+    for token in tokens:
+        if not isinstance(token, dict):
+            continue
+        page = token.get("pageIdToken") or {}
+        pid = page.get("pageId")
+        if isinstance(pid, str) and re.fullmatch(r"\d{21}", pid):
+            return pid
+    return None
+
+
+def run_test(rows: list[CookieRow], cfg: TestConfig, client_version: str) -> TestResult:
+    filtered = filter_rows(rows, cfg.cookie_mode)
+    cookie = cookie_header(filtered)
+    auth = None
+    if not cfg.skip_auth:
+        sap = pick_sapisid(rows, cfg.sapisid_strategy)
+        if not sap:
+            return TestResult(
+                config=cfg,
+                account_menu_status=0,
+                account_signed_in=False,
+                account_name=None,
+                browse_playlists_status=0,
+                browse_has_library=False,
+                browse_error_snippet=None,
+                error=f"no SAPISID for strategy {cfg.sapisid_strategy}",
+            )
+        auth = sapisid_hash(sap)
+
+    am_status, am_body = innertube_post(cfg, cookie, auth, "account/account_menu", {}, client_version)
+    signed_in, name = (False, None)
+    if isinstance(am_body, dict):
+        signed_in, name = parse_account_menu(am_body)
+
+    br_status, br_body = innertube_post(
+        cfg, cookie, auth, "browse", {"browseId": "FEmusic_liked_playlists"}, client_version
+    )
+    has_lib, br_err = parse_browse_library(br_body)
+
+    al_status: int | None = None
+    channels: list[dict[str, Any]] = []
+    if signed_in or cfg.brand_id:
+        al_status, al_body = innertube_post(
+            cfg,
+            cookie,
+            auth,
+            "account/accounts_list",
+            {},
+            client_version,
+        )
+        if isinstance(al_body, dict):
+            channels = collect_channels(al_body)
+
+    return TestResult(
+        config=cfg,
+        account_menu_status=am_status,
+        account_signed_in=signed_in,
+        account_name=name,
+        browse_playlists_status=br_status,
+        browse_has_library=has_lib,
+        browse_error_snippet=br_err if not has_lib else None,
+        accounts_list_status=al_status,
+        channel_count=len(channels),
+        channels=channels,
+    )
+
+
+def build_matrix(brand_id: str | None, live_version: str) -> list[TestConfig]:
+    configs: list[TestConfig] = []
+    for cookie_mode in ("all", "youtube", "google"):
+        for sap in ("flat-3p-then-s", "google-sapisid-first", "yt-3papisid", "google-sapisid"):
+            configs.append(
+                TestConfig(
+                    label=f"cookies={cookie_mode} hash={sap}",
+                    cookie_mode=cookie_mode,
+                    sapisid_strategy=sap,
+                )
+            )
+    for authuser in ("0", "1", "2"):
+        configs.append(
+            TestConfig(
+                label=f"authuser={authuser}",
+                authuser=authuser,
+            )
+        )
+    configs.append(TestConfig(label="live-client-version", client_version=live_version))
+    configs.append(TestConfig(label="default-client-version", client_version=DEFAULT_CLIENT_VERSION))
+    if brand_id:
+        configs.append(TestConfig(label=f"brand={brand_id}", brand_id=brand_id))
+    return configs
+
+
+def print_report(results: list[TestResult], source: str) -> None:
+    print(f"\n{'=' * 72}")
+    print(f"YTubic Auth Lab — source: {source}")
+    print(f"{'=' * 72}\n")
+
+    winners = [r for r in results if r.account_signed_in and r.browse_has_library]
+    partial = [r for r in results if r.account_signed_in and not r.browse_has_library]
+    anon = [r for r in results if not r.account_signed_in and not r.error]
+
+    if winners:
+        print("WORKING (signed in + library):\n")
+        for r in winners:
+            ch = f", channels={r.channel_count}" if r.channel_count else ""
+            print(f"  ✓ {r.config.label}")
+            print(f"    account={r.account_name!r}  browse HTTP {r.browse_playlists_status}{ch}")
+            if r.channels:
+                for c in r.channels:
+                    mark = " *" if c.get("isSelected") else ""
+                    bid = c.get("brandId") or "primary"
+                    print(f"      - {c['name']} ({c.get('handle') or bid}){mark}")
+        print()
+    else:
+        print("No configuration fully worked (account + library).\n")
+
+    if partial:
+        print("PARTIAL (signed in, library failed):\n")
+        for r in partial[:8]:
+            print(f"  ~ {r.config.label} — browse HTTP {r.browse_playlists_status}: {r.browse_error_snippet}")
+        print()
+
+    if anon:
+        print(f"Anonymous / failed account_menu: {len(anon)} configs\n")
+
+    errors = [r for r in results if r.error]
+    if errors:
+        print("ERRORS:\n")
+        for r in errors:
+            print(f"  ! {r.config.label}: {r.error}")
+        print()
+
+    print("All results:")
+    for r in results:
+        status = "OK" if r.account_signed_in and r.browse_has_library else (
+            "PARTIAL" if r.account_signed_in else "FAIL"
+        )
+        if r.error:
+            status = "ERROR"
+        print(
+            f"  [{status:7}] {r.config.label:40} "
+            f"menu={r.account_menu_status} account={'yes' if r.account_signed_in else 'no':3} "
+            f"browse={r.browse_playlists_status} lib={'yes' if r.browse_has_library else 'no'}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Test YT Music InnerTube auth strategies")
+    parser.add_argument("source", choices=["ytubic", "file"], help="cookie source")
+    parser.add_argument("path", nargs="?", help="path to Netscape cookies.txt when source=file")
+    parser.add_argument("--brand", help="21-digit brand id to test onBehalfOfUser")
+    parser.add_argument("--json", dest="json_out", help="write full results JSON here")
+    parser.add_argument("--quick", action="store_true", help="run fewer combinations")
+    args = parser.parse_args()
+
+    if args.source == "ytubic":
+        netscape, path = load_ytubic_netscape()
+        source_label = str(path)
+    else:
+        if not args.path:
+            print("file source requires path to cookies.txt", file=sys.stderr)
+            return 2
+        p = Path(args.path)
+        netscape = p.read_text(encoding="utf-8")
+        source_label = str(p)
+
+    rows = parse_netscape(netscape)
+    live_ver = fetch_client_version()
+    print(f"Loaded {len(rows)} cookie rows from {source_label}")
+    print(f"Live YTM client version: {live_ver}")
+
+    if args.quick:
+        configs = [
+            TestConfig("quick-all-flat", "all", "flat-3p-then-s"),
+            TestConfig("quick-all-google-sap", "all", "google-sapisid-first"),
+            TestConfig("quick-youtube-only", "youtube", "yt-3papisid"),
+        ]
+        if args.brand:
+            configs.append(TestConfig(f"quick-brand", brand_id=args.brand))
+    else:
+        configs = build_matrix(args.brand, live_ver)
+
+    results: list[TestResult] = []
+    for cfg in configs:
+        ver = cfg.client_version or live_ver
+        results.append(run_test(rows, cfg, ver))
+        time.sleep(0.15)
+
+    print_report(results, source_label)
+
+    if args.json_out:
+        out = []
+        for r in results:
+            out.append(
+                {
+                    "label": r.config.label,
+                    "account_signed_in": r.account_signed_in,
+                    "account_name": r.account_name,
+                    "browse_has_library": r.browse_has_library,
+                    "browse_status": r.browse_playlists_status,
+                    "channels": r.channels,
+                    "error": r.error,
+                }
+            )
+        Path(args.json_out).write_text(json.dumps(out, indent=2), encoding="utf-8")
+        print(f"Wrote {args.json_out}")
+
+    return 0 if any(r.account_signed_in and r.browse_has_library for r in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/auth-lab/probe_channels.py
+++ b/scripts/auth-lab/probe_channels.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Probe YouTube channel-switcher endpoints."""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from auth_lab import (  # noqa: E402
+    TestConfig,
+    collect_channels,
+    cookie_header,
+    fetch_client_version,
+    filter_rows,
+    innertube_post,
+    load_ytubic_netscape,
+    parse_netscape,
+    pick_sapisid,
+    sapisid_hash,
+)
+
+WEB_VERSION = "2.20250312.01.00"
+UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+
+def post_custom(
+    origin: str,
+    client_name: str,
+    client_num: int,
+    endpoint: str,
+    body: dict,
+    cookie: str,
+    sap: str | None,
+    ver: str,
+) -> tuple[int, object]:
+    user = {"lockedSafetyMode": False}
+    cv = ver if client_name == "WEB_REMIX" else WEB_VERSION
+    client: dict = {
+        "clientName": client_name,
+        "clientVersion": cv,
+        "hl": "en",
+        "gl": "US",
+        "platform": "DESKTOP",
+        "userAgent": f"{UA},gzip(gfe)",
+    }
+    if client_name == "WEB_REMIX":
+        client["originalUrl"] = f"{origin}/"
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": UA,
+        "X-YouTube-Client-Name": str(client_num),
+        "X-YouTube-Client-Version": cv,
+        "Origin": origin,
+        "Referer": f"{origin}/",
+        "Cookie": cookie,
+        "X-Goog-AuthUser": "0",
+    }
+    if sap:
+        headers["Authorization"] = sapisid_hash(sap, origin)
+    payload = {
+        "context": {"client": client, "user": user, "request": {"useSsl": True}},
+        **body,
+    }
+    url = f"{origin}/youtubei/v1/{endpoint}?prettyPrint=false"
+    req = urllib.request.Request(
+        url, data=json.dumps(payload).encode(), headers=headers, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return r.status, json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", errors="replace")[:400]
+
+
+def get_switcher(origin: str, cookie: str, sap: str | None) -> tuple[int, str]:
+    headers = {"User-Agent": UA, "Cookie": cookie}
+    if sap:
+        headers["Authorization"] = sapisid_hash(sap, origin)
+    req = urllib.request.Request(f"{origin}/getAccountSwitcherEndpoint", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return r.status, r.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", errors="replace")[:600]
+
+
+def main() -> None:
+    plain, _ = load_ytubic_netscape()
+    rows = parse_netscape(plain)
+    yt = filter_rows(rows, "youtube")
+    cookie = cookie_header(yt)
+    sap = pick_sapisid(rows, "flat-3p-then-s")
+    auth = sapisid_hash(sap) if sap else None
+    ver = fetch_client_version()
+    cfg = TestConfig(label="t", cookie_mode="youtube")
+
+    _, menu = innertube_post(cfg, cookie, auth, "account/account_menu", {}, ver)
+    print("account_menu channels:", collect_channels(menu))
+    print(
+        "account_menu flags:",
+        {
+            k: k in json.dumps(menu)
+            for k in (
+                "selectActiveIdentityEndpoint",
+                "accountItem",
+                "channelHandle",
+                "accountSectionListRenderer",
+            )
+        },
+    )
+
+    bodies = [
+        (
+            "CHANNEL_SWITCHER FULL",
+            {
+                "requestType": "ACCOUNTS_LIST_REQUEST_TYPE_CHANNEL_SWITCHER",
+                "callCircumstance": "SWITCHING_USERS_FULL",
+            },
+        ),
+        (
+            "CHANNEL_SWITCHER",
+            {
+                "requestType": "ACCOUNTS_LIST_REQUEST_TYPE_CHANNEL_SWITCHER",
+                "callCircumstance": "SWITCHING_USERS",
+            },
+        ),
+        ("empty", {}),
+    ]
+    for label, body in bodies:
+        for host, cname, cnum in (
+            ("https://www.youtube.com", "WEB", 1),
+            ("https://music.youtube.com", "WEB_REMIX", 67),
+        ):
+            st, resp = post_custom(host, cname, cnum, "account/accounts_list", body, cookie, sap, ver)
+            ch = collect_channels(resp) if isinstance(resp, dict) else []
+            keys = list(resp.keys()) if isinstance(resp, dict) else ["err"]
+            print(f"{host} {cname} {label}: st={st} ch={len(ch)} keys={keys}")
+            if ch:
+                for c in ch:
+                    print(" ", c)
+
+    for host in ("https://www.youtube.com", "https://music.youtube.com"):
+        st, text = get_switcher(host, cookie, sap)
+        print(f"GET switcher {host}: st={st} len={len(text)}")
+        if text.startswith(")]}'"):
+            data = json.loads(text[4:])
+            ch = collect_channels(data)
+            print("  channels:", ch)
+            out = Path(__file__).parent / f"switcher_{host.split('//')[1].replace('.', '_')}.json"
+            out.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            print("  wrote", out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/auth-lab/run-file.bat
+++ b/scripts/auth-lab/run-file.bat
@@ -1,0 +1,8 @@
+@echo off
+cd /d "%~dp0"
+if "%~1"=="" (
+  echo Usage: run-file.bat path\to\cookies.txt
+  exit /b 1
+)
+python auth_lab.py file "%~1" %*
+pause

--- a/scripts/auth-lab/run-ytubic.bat
+++ b/scripts/auth-lab/run-ytubic.bat
@@ -1,0 +1,4 @@
+@echo off
+cd /d "%~dp0"
+python auth_lab.py ytubic %*
+pause

--- a/scripts/fetch_ytm_version.py
+++ b/scripts/fetch_ytm_version.py
@@ -1,0 +1,16 @@
+import re
+import urllib.request
+
+html = urllib.request.urlopen("https://music.youtube.com", timeout=15).read().decode(
+    "utf-8", "replace"
+)
+for pattern in [
+    r'INNERTUBE_CLIENT_VERSION":"([^"]+)"',
+    r'"clientVersion":"([^"]+)"',
+]:
+    m = re.search(pattern, html)
+    if m:
+        print(m.group(1))
+        break
+else:
+    print("not found")

--- a/scripts/probe_innertube.py
+++ b/scripts/probe_innertube.py
@@ -1,0 +1,173 @@
+import ctypes
+import ctypes.wintypes as wt
+import hashlib
+import json
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+class DATA_BLOB(ctypes.Structure):
+    _fields_ = [("cbData", wt.DWORD), ("pbData", ctypes.POINTER(ctypes.c_char))]
+
+
+def decrypt(data: bytes, entropy: bytes) -> bytes:
+    CryptUnprotectData = ctypes.windll.crypt32.CryptUnprotectData
+    LocalFree = ctypes.windll.kernel32.LocalFree
+    in_blob = DATA_BLOB(
+        len(data),
+        ctypes.cast(ctypes.create_string_buffer(data), ctypes.POINTER(ctypes.c_char)),
+    )
+    ent_blob = DATA_BLOB(
+        len(entropy),
+        ctypes.cast(ctypes.create_string_buffer(entropy), ctypes.POINTER(ctypes.c_char)),
+    )
+    out_blob = DATA_BLOB()
+    if not CryptUnprotectData(
+        ctypes.byref(in_blob), None, ctypes.byref(ent_blob), None, None, 0, ctypes.byref(out_blob)
+    ):
+        raise OSError("CryptUnprotectData failed")
+    buf = ctypes.string_at(out_blob.pbData, out_blob.cbData)
+    LocalFree(out_blob.pbData)
+    return buf
+
+
+def build_cookie_header(plain: str, youtube_only: bool = False) -> str:
+    parts: list[str] = []
+    seen: set[str] = set()
+    for line in plain.splitlines():
+        if line.startswith("#") or not line.strip():
+            continue
+        fields = line.split("\t")
+        if len(fields) < 7:
+            continue
+        dom = fields[0].lstrip(".")
+        if youtube_only:
+            if not dom.endswith("youtube.com"):
+                continue
+        elif not (dom.endswith("youtube.com") or dom.endswith("google.com")):
+            continue
+        key = f"{fields[5]}@{dom}"
+        if key in seen:
+            continue
+        seen.add(key)
+        parts.append(f"{fields[5]}={fields[6]}")
+    return "; ".join(parts)
+
+
+def sapisid_hash(cookie: str, origin: str) -> str:
+    sapisid = None
+    for part in cookie.split("; "):
+        if part.startswith("__Secure-3PAPISID="):
+            sapisid = part.split("=", 1)[1]
+            break
+        if part.startswith("SAPISID="):
+            sapisid = part.split("=", 1)[1]
+    ts = int(time.time())
+    digest = hashlib.sha1(f"{ts} {sapisid} {origin}".encode()).hexdigest()
+    return f"SAPISIDHASH {ts}_{digest}"
+
+
+def post(cookie: str, endpoint: str, body: dict, brand_id: str | None = None) -> tuple[int, dict | str]:
+    origin = "https://music.youtube.com"
+    ver = "1.20260510.02.00"
+    user: dict = {"lockedSafetyMode": False}
+    if brand_id:
+        user["onBehalfOfUser"] = brand_id
+    ctx = {
+        "client": {
+            "clientName": "WEB_REMIX",
+            "clientVersion": ver,
+            "hl": "en",
+            "gl": "US",
+            "platform": "DESKTOP",
+            "userAgent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36,gzip(gfe)"
+            ),
+            "originalUrl": "https://music.youtube.com/",
+        },
+        "user": user,
+        "request": {"useSsl": True},
+    }
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "X-YouTube-Client-Name": "67",
+        "X-YouTube-Client-Version": ver,
+        "Origin": origin,
+        "Referer": origin + "/",
+        "X-Origin": origin,
+        "X-Goog-AuthUser": "0",
+        "Cookie": cookie,
+        "Authorization": sapisid_hash(cookie, origin),
+    }
+    data = json.dumps({"context": ctx, **body}).encode()
+    req = urllib.request.Request(
+        f"https://music.youtube.com/youtubei/v1/{endpoint}?prettyPrint=false",
+        data=data,
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", errors="replace")[:500]
+
+
+def main() -> None:
+    import sys
+
+    if len(sys.argv) < 2:
+        appdata = Path.home() / "AppData" / "Roaming" / "com.github.ivasy.ytubic"
+        index_path = appdata / "accounts.json"
+        if not index_path.exists():
+            print("Usage: python probe_innertube.py <cookies.enc path>", file=sys.stderr)
+            print("Or sign in to YTubic first (needs accounts.json in AppData).", file=sys.stderr)
+            sys.exit(1)
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+        active = index.get("active")
+        if not active:
+            print("No active YTubic account.", file=sys.stderr)
+            sys.exit(1)
+        path = appdata / "accounts" / active / "cookies.enc"
+    else:
+        path = Path(sys.argv[1])
+    plain = decrypt(path.read_bytes(), b"ytm-native/cookies.enc v1").decode("utf-8")
+    for label, yt_only in [("all google+youtube", False), ("youtube only", True)]:
+        cookie = build_cookie_header(plain, youtube_only=yt_only)
+        print(f"\n=== {label} ===")
+        print(f"Cookie header length: {len(cookie)}")
+        print(f"Has LOGIN_INFO: {'LOGIN_INFO' in cookie}")
+        print(f"Has __Secure-1PSID: {'__Secure-1PSID' in cookie}")
+
+        for endpoint, body in [
+            ("account/account_menu", {}),
+            ("browse", {"browseId": "FEmusic_liked_playlists"}),
+        ]:
+            status, payload = post(cookie, endpoint, body)
+            print(f"\n{endpoint} -> HTTP {status}")
+            if isinstance(payload, dict):
+                if endpoint == "account/account_menu":
+                    header = (
+                        payload.get("actions", [{}])[0]
+                        .get("openPopupAction", {})
+                        .get("popup", {})
+                        .get("multiPageMenuRenderer", {})
+                        .get("header", {})
+                        .get("activeAccountHeaderRenderer")
+                    )
+                    print("  activeAccountHeaderRenderer:", "yes" if header else "NO (anonymous)")
+                if endpoint == "browse":
+                    blob = json.dumps(payload)[:1500].lower()
+                    print("  contains sign-in prompt:", "sign in" in blob)
+            else:
+                print(" ", payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/start-ytubic.bat
+++ b/scripts/start-ytubic.bat
@@ -1,0 +1,3 @@
+@echo off
+cd /d "%~dp0.."
+pnpm tauri dev

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -57,6 +57,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.4",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +117,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +154,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -879,6 +923,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +977,12 @@ dependencies = [
  "selectors 0.36.1",
  "tendril 0.5.0",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -3026,7 +3085,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3070,6 +3129,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "potential_utf"
@@ -3206,6 +3271,15 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -3557,6 +3631,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3752,6 +3850,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4017,6 +4121,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -5548,6 +5663,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.4",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6364,8 +6539,10 @@ dependencies = [
  "axum",
  "cookie",
  "reqwest 0.12.28",
+ "rfd",
  "serde",
  "serde_json",
+ "sha1",
  "tauri",
  "tauri-build",
  "tauri-plugin-http",
@@ -6552,6 +6729,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 0.7.15",
  "zvariant_derive",
  "zvariant_utils",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,11 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
+[features]
+# Enabled automatically by `pnpm tauri build`. Without it the app loads
+# `devUrl` (localhost:1420) even from a release binary.
+custom-protocol = ["tauri/custom-protocol"]
+
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-opener = "2"
@@ -28,7 +33,7 @@ serde_json = "1"
 tauri-plugin-http = { version = "2", features = ["unsafe-headers"] }
 tauri-plugin-store = "2"
 tauri-plugin-shell = "2"
-reqwest = { version = "0.12", default-features = false, features = ["native-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["native-tls", "json"] }
 urlencoding = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "io-util", "process", "sync", "net"] }
 axum = "0.7"
@@ -36,8 +41,10 @@ tower-http = { version = "0.6", features = ["cors", "fs"] }
 tower = "0.5"
 cookie = "0.18"
 time = "0.3"
+rfd = "0.15"
 tauri-plugin-updater = "2.10.1"
 tauri-plugin-process = "2.3.1"
+sha1 = "0.10"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [

--- a/src-tauri/src/dev_server.rs
+++ b/src-tauri/src/dev_server.rs
@@ -1,0 +1,65 @@
+//! When the app is built without `custom-protocol` (e.g. `cargo build
+//! --release` instead of `pnpm tauri build`), Tauri loads the UI from
+//! `devUrl` (`http://localhost:1420`). Start Vite automatically so a
+//! double-clicked `.exe` still works during local development.
+
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+const DEV_PORT: u16 = 1420;
+
+fn port_open() -> bool {
+    TcpStream::connect_timeout(
+        &format!("127.0.0.1:{DEV_PORT}").parse().expect("addr"),
+        Duration::from_millis(250),
+    )
+    .is_ok()
+}
+
+fn project_root() -> Option<&'static Path> {
+    Path::new(env!("CARGO_MANIFEST_DIR")).parent()
+}
+
+fn spawn_vite(root: &Path) {
+    eprintln!("[dev-server] starting Vite on http://localhost:{DEV_PORT} …");
+    let mut cmd = Command::new("pnpm");
+    cmd.args(["dev"]).current_dir(root);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    match cmd.spawn() {
+        Ok(_) => {}
+        Err(e) => eprintln!("[dev-server] failed to spawn `pnpm dev`: {e}"),
+    }
+}
+
+/// Block briefly until Vite is listening or we give up.
+pub fn ensure_vite_for_dev_build() {
+    if !tauri::is_dev() {
+        return;
+    }
+    if port_open() {
+        return;
+    }
+    let Some(root) = project_root() else {
+        return;
+    };
+    if !root.join("package.json").exists() {
+        eprintln!("[dev-server] no package.json at {root:?} — cannot auto-start Vite");
+        return;
+    }
+    spawn_vite(root);
+    for _ in 0..40 {
+        if port_open() {
+            eprintln!("[dev-server] Vite ready on :{DEV_PORT}");
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    eprintln!("[dev-server] timed out waiting for :{DEV_PORT} — run `pnpm dev` manually");
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -23,6 +23,8 @@ use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use tower::ServiceExt;
 use tower_http::cors::CorsLayer;
 use tower_http::services::ServeFile;
+
+mod dev_server;
 
 mod ytdlp;
 
@@ -149,6 +151,13 @@ struct Account {
     name: String,
     #[serde(default, rename = "photoUrl")]
     photo_url: Option<String>,
+    /// YouTube brand-channel id (`onBehalfOfUser`). `None` = primary channel.
+    #[serde(default, rename = "brandId")]
+    brand_id: Option<String>,
+    #[serde(default, rename = "channelName")]
+    channel_name: Option<String>,
+    #[serde(default, rename = "channelHandle")]
+    channel_handle: Option<String>,
     /// Unix seconds when this account was first added.
     #[serde(default, rename = "addedAt")]
     added_at: i64,
@@ -175,8 +184,120 @@ struct AccountSummary {
     name: String,
     #[serde(rename = "photoUrl")]
     photo_url: Option<String>,
+    #[serde(rename = "brandId")]
+    brand_id: Option<String>,
+    #[serde(rename = "channelName")]
+    channel_name: Option<String>,
+    #[serde(rename = "channelHandle")]
+    channel_handle: Option<String>,
     #[serde(rename = "isActive")]
     is_active: bool,
+}
+
+/// InnerTube WEB_REMIX client version — keep in sync with shared.ts.
+const INNERTUBE_CLIENT_VERSION: &str = "1.20260510.02.00";
+const INNERTUBE_ORIGIN: &str = "https://music.youtube.com";
+
+/// Matches [`src/lib/innertube/shared.ts`] `DESKTOP_UA` — keep in sync.
+const INNERTUBE_USER_AGENT: &str =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+     (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+/// Build a `Cookie:` header for InnerTube. **YouTube-only** — sending
+/// google.com cookies together with youtube.com breaks `account_menu`
+/// (verified in scripts/auth-lab). SAPISIDHASH still uses youtube SAPISID.
+fn cookie_header_from_netscape(content: &str) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for line in content.lines() {
+        if line.starts_with('#') || line.trim().is_empty() {
+            continue;
+        }
+        let fields: Vec<&str> = line.split('\t').collect();
+        if fields.len() < 7 {
+            continue;
+        }
+        let bare = fields[0].trim_start_matches('.');
+        if !bare.ends_with("youtube.com") {
+            continue;
+        }
+        let name = fields[5];
+        let value = fields[6];
+        if !seen.insert(name.to_string()) {
+            continue;
+        }
+        parts.push(format!("{name}={value}"));
+    }
+    parts.join("; ")
+}
+
+fn sapisid_for_hash_from_netscape(content: &str) -> Option<String> {
+    let mut yt_3p = None;
+    let mut yt_s = None;
+    for line in content.lines() {
+        if line.starts_with('#') || line.trim().is_empty() {
+            continue;
+        }
+        let fields: Vec<&str> = line.split('\t').collect();
+        if fields.len() < 7 {
+            continue;
+        }
+        let bare = fields[0].trim_start_matches('.');
+        if !bare.ends_with("youtube.com") {
+            continue;
+        }
+        let name = fields[5];
+        let value = fields[6];
+        match name {
+            "__Secure-3PAPISID" => yt_3p = Some(value.to_string()),
+            "SAPISID" => yt_s = Some(value.to_string()),
+            _ => {}
+        }
+    }
+    yt_3p.or(yt_s)
+}
+
+fn sapisid_hash_value(sapisid: &str, origin: &str) -> Option<String> {
+    let ts = time::OffsetDateTime::now_utc().unix_timestamp();
+    use sha1::{Digest, Sha1};
+    let mut hasher = Sha1::new();
+    hasher.update(format!("{ts} {sapisid} {origin}"));
+    let hash = format!("{:x}", hasher.finalize());
+    Some(format!("SAPISIDHASH {ts}_{hash}"))
+}
+
+#[derive(serde::Serialize)]
+struct InnertubeAuthHeaders {
+    #[serde(rename = "cookieHeader")]
+    cookie_header: String,
+    authorization: String,
+}
+
+fn build_innertube_auth_from_netscape(content: &str) -> Option<InnertubeAuthHeaders> {
+    let cookie_header = cookie_header_from_netscape(content);
+    if cookie_header.is_empty() {
+        return None;
+    }
+    let sapisid = sapisid_for_hash_from_netscape(content)?;
+    let authorization = sapisid_hash_value(&sapisid, INNERTUBE_ORIGIN)?;
+    Some(InnertubeAuthHeaders {
+        cookie_header,
+        authorization,
+    })
+}
+
+#[derive(Default)]
+struct LoginConfirm(StdMutex<Option<Arc<AtomicBool>>>);
+
+/// One parsed line from a Netscape cookie-jar export.
+#[derive(Clone, Debug)]
+struct NetscapeLine {
+    domain: String,
+    path: String,
+    secure: bool,
+    expiry: i64,
+    name: String,
+    value: String,
 }
 
 fn accounts_dir(app: &tauri::AppHandle) -> PathBuf {
@@ -310,6 +431,213 @@ fn generate_account_id() -> String {
     format!("acct-{:x}", nanos)
 }
 
+/// Parse a Netscape cookie-jar export. Supports `#HttpOnly_` prefix lines
+/// and skips comment / header lines.
+fn parse_netscape_cookies(text: &str) -> Result<Vec<NetscapeLine>, String> {
+    let mut out = Vec::new();
+    for raw_line in text.lines() {
+        let line = raw_line.trim_end();
+        if line.is_empty() {
+            continue;
+        }
+        let line = if let Some(rest) = line.strip_prefix("#HttpOnly_") {
+            rest
+        } else if line.starts_with('#') {
+            continue;
+        } else {
+            line
+        };
+        let fields: Vec<&str> = line.splitn(7, '\t').collect();
+        if fields.len() < 7 {
+            return Err(format!(
+                "invalid cookie line (expected 7 tab-separated fields): {}",
+                line.chars().take(80).collect::<String>()
+            ));
+        }
+        out.push(NetscapeLine {
+            domain: fields[0].to_string(),
+            path: fields[2].to_string(),
+            secure: fields[3] == "TRUE",
+            expiry: fields[4].parse().unwrap_or(0),
+            name: fields[5].to_string(),
+            value: fields[6].to_string(),
+        });
+    }
+    if out.is_empty() {
+        return Err("no cookies found in input".into());
+    }
+    Ok(out)
+}
+
+/// Require at least one auth cookie InnerTube can use (youtube or google).
+fn validate_yt_auth_cookies(lines: &[NetscapeLine]) -> Result<(), String> {
+    let auth_names = [
+        "SAPISID",
+        "__Secure-1PSID",
+        "__Secure-3PAPISID",
+        "SID",
+        "LOGIN_INFO",
+    ];
+    let ok = lines.iter().any(|c| {
+        let bare = c.domain.trim_start_matches('.');
+        let is_google = bare == "google.com" || bare.ends_with(".google.com");
+        let is_yt = bare == "youtube.com" || bare.ends_with(".youtube.com");
+        (is_google || is_yt) && auth_names.contains(&c.name.as_str())
+    });
+    if ok {
+        Ok(())
+    } else {
+        Err(
+            "missing required auth cookies — export cookies for both youtube.com and google.com \
+             (need SAPISID, __Secure-1PSID, or LOGIN_INFO)"
+                .into(),
+        )
+    }
+}
+
+/// Serialize parsed lines back to Netscape format, keeping only
+/// google/youtube domains (same filter as `cookies_to_netscape`).
+/// Normalizes every line to `.{domain}\tTRUE` so `read_innertube_cookie_header`
+/// can match `music.youtube.com` — browser exporters often emit
+/// `youtube.com\tFALSE`, which would silently drop SAPISID / PSID.
+fn netscape_lines_to_text(lines: &[NetscapeLine]) -> String {
+    let mut out = String::from("# Netscape HTTP Cookie File\n");
+    for c in lines {
+        let bare = c.domain.trim_start_matches('.');
+        let allowed = bare == "youtube.com"
+            || bare.ends_with(".youtube.com")
+            || bare == "google.com"
+            || bare.ends_with(".google.com");
+        if !allowed {
+            continue;
+        }
+        let dom_out = format!(".{bare}");
+        let secure = if c.secure { "TRUE" } else { "FALSE" };
+        out.push_str(&format!(
+            "{}\tTRUE\t{}\t{}\t{}\t{}\t{}\n",
+            dom_out, c.path, secure, c.expiry, c.name, c.value
+        ));
+    }
+    out
+}
+
+/// Shared path for cookie import and WebView login: encrypt the jar,
+/// register a new account row, flip it active, emit `login-success`.
+async fn register_account_from_netscape(
+    app: &tauri::AppHandle,
+    netscape: String,
+) -> Result<String, String> {
+    let lines = parse_netscape_cookies(&netscape)?;
+    validate_yt_auth_cookies(&lines)?;
+    let filtered = netscape_lines_to_text(&lines);
+    if filtered.lines().count() <= 1 {
+        return Err("no google/youtube cookies found after filtering".into());
+    }
+
+    let new_id = generate_account_id();
+    let cookies_path = account_cookies_path(app, &new_id);
+    if let Some(dir) = cookies_path.parent() {
+        tokio::fs::create_dir_all(dir)
+            .await
+            .map_err(|e| format!("mkdir account dir: {e}"))?;
+    }
+    let plain = filtered.into_bytes();
+    let encrypted = tokio::task::spawn_blocking(move || secure_store::encrypt(&plain))
+        .await
+        .map_err(|e| format!("encrypt join: {e}"))?
+        .map_err(|e| format!("encrypt cookies: {e}"))?;
+    tokio::fs::write(&cookies_path, &encrypted)
+        .await
+        .map_err(|e| format!("write account cookies: {e}"))?;
+
+    let mut idx = read_index(app).await;
+    let now_s = time::OffsetDateTime::now_utc().unix_timestamp();
+    idx.accounts.push(Account {
+        id: new_id.clone(),
+        added_at: now_s,
+        ..Default::default()
+    });
+    idx.active = Some(new_id.clone());
+    write_index(app, &idx).await?;
+    let _ = app.emit("login-success", &new_id);
+    Ok(new_id)
+}
+
+#[tauri::command]
+async fn import_cookies_from_text(
+    app: tauri::AppHandle,
+    text: String,
+) -> Result<String, String> {
+    register_account_from_netscape(&app, text).await
+}
+
+#[tauri::command]
+async fn import_cookies_from_file(app: tauri::AppHandle) -> Result<String, String> {
+    let path = rfd::FileDialog::new()
+        .add_filter("Cookie files", &["txt"])
+        .add_filter("All files", &["*"])
+        .set_title("Import Netscape cookie file")
+        .pick_file()
+        .ok_or_else(|| "no file selected".to_string())?;
+    let text = tokio::fs::read_to_string(&path)
+        .await
+        .map_err(|e| format!("read file: {e}"))?;
+    register_account_from_netscape(&app, text).await
+}
+
+#[tauri::command]
+async fn get_active_brand_id(app: tauri::AppHandle) -> Result<Option<String>, String> {
+    let idx = read_index(&app).await;
+    let active = idx.active.as_deref();
+    Ok(idx
+        .accounts
+        .iter()
+        .find(|a| active == Some(a.id.as_str()))
+        .and_then(|a| a.brand_id.clone()))
+}
+
+#[tauri::command]
+async fn set_active_brand(
+    app: tauri::AppHandle,
+    id: String,
+    #[allow(non_snake_case)] brandId: Option<String>,
+    #[allow(non_snake_case)] channelName: Option<String>,
+    #[allow(non_snake_case)] channelHandle: Option<String>,
+) -> Result<(), String> {
+    let brand_id = brandId;
+    let channel_name = channelName;
+    let channel_handle = channelHandle;
+    let mut idx = read_index(&app).await;
+    let acct = idx
+        .accounts
+        .iter_mut()
+        .find(|a| a.id == id)
+        .ok_or_else(|| format!("no such account: {id}"))?;
+    acct.brand_id = brand_id;
+    acct.channel_name = channel_name;
+    acct.channel_handle = channel_handle;
+    write_index(&app, &idx).await?;
+    // Brand switches stay on the same Google account — don't fire
+    // `accounts-changed`, which nukes the query cache and navigates
+    // home (can crash/reload the WebView on Windows).
+    let _ = app.emit("brand-changed", ());
+    Ok(())
+}
+
+/// User clicked "Continue" in the login window after cookies were detected.
+#[tauri::command]
+fn confirm_login(state: tauri::State<'_, LoginConfirm>) -> Result<(), String> {
+    let guard = state
+        .0
+        .lock()
+        .map_err(|e| format!("lock: {e}"))?;
+    let Some(flag) = guard.as_ref() else {
+        return Err("no login in progress".into());
+    };
+    flag.store(true, Ordering::Release);
+    Ok(())
+}
+
 /// Read the encrypted cookie jar for the active account and decrypt
 /// it in memory. Returns `None` when nobody is signed in or
 /// decryption fails (treat as logged-out).
@@ -421,10 +749,7 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
         .min_inner_size(420.0, 560.0)
         .center()
         .data_directory(webview_data.clone())
-        .user_agent(
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
-             (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
-        )
+        .user_agent(INNERTUBE_USER_AGENT)
         // Surface the current origin in the title so the user can spot
         // a redirect to an unexpected host (anti-phishing).
         .on_page_load(|win, payload| {
@@ -436,19 +761,46 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
 
     let app_poll = app.clone();
     let cleanup_dir = webview_data.clone();
+    let confirm_flag = Arc::new(AtomicBool::new(false));
+    if let Ok(mut guard) = app.state::<LoginConfirm>().0.lock() {
+        *guard = Some(confirm_flag.clone());
+    }
     tauri::async_runtime::spawn(async move {
         // Set to true once we've redirected the webview to YT ourselves.
         // Guards against thrashing if YT auto-sign-in is slow and we
         // catch a Google-auth-only state on multiple ticks.
         let mut nudged_to_yt = false;
+        let mut insecure_emitted = false;
+        let mut login_ready_emitted = false;
+        let mut confirm_ticks: u32 = 0;
         loop {
             tokio::time::sleep(Duration::from_millis(1500)).await;
 
             let Some(win) = app_poll.get_webview_window("login") else {
                 let _ = app_poll.emit("login-cancelled", ());
+                if let Ok(mut guard) = app_poll.state::<LoginConfirm>().0.lock() {
+                    *guard = None;
+                }
                 let _ = tokio::fs::remove_dir_all(&cleanup_dir).await;
                 return;
             };
+
+            let user_confirmed = confirm_flag.load(Ordering::Acquire);
+            if user_confirmed {
+                confirm_ticks += 1;
+            }
+
+            let current_url = win.url().map(|u| u.to_string()).unwrap_or_default();
+            let url_lower = current_url.to_lowercase();
+            if !insecure_emitted
+                && (url_lower.contains("signin/rejected")
+                    || url_lower.contains("browsernotsecure")
+                    || url_lower.contains("couldn"))
+            {
+                let _ = app_poll.emit("login-insecure-browser", ());
+                insecure_emitted = true;
+                let _ = win.set_title("Sign in — Google blocked this browser");
+            }
 
             let cookies = match win.cookies() {
                 Ok(c) => c,
@@ -460,13 +812,32 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
 
             let has_yt_auth = cookies.iter().any(|c| {
                 let name = c.name();
-                (name == "__Secure-1PSID" || name == "SAPISID")
-                    && c.domain()
-                        .map(|d| d.trim_start_matches('.').ends_with("youtube.com"))
-                        .unwrap_or(false)
+                let is_auth = name == "__Secure-1PSID"
+                    || name == "__Secure-3PSID"
+                    || name == "SAPISID"
+                    || name == "SID";
+                is_auth
+                    && c.domain().map(|d| {
+                        let bare = d.trim_start_matches('.');
+                        bare.ends_with("youtube.com") || bare.ends_with("google.com")
+                    }).unwrap_or(false)
             });
 
+            let on_music_yt = url_lower.contains("music.youtube.com");
+
             if !has_yt_auth {
+                if user_confirmed && confirm_ticks >= 20 {
+                    let _ = app_poll.emit(
+                        "login-failed",
+                        "No YouTube session found. In the login window, open music.youtube.com and sign in there, then click Continue — or use Import cookies below.",
+                    );
+                    let _ = win.close();
+                    if let Ok(mut guard) = app_poll.state::<LoginConfirm>().0.lock() {
+                        *guard = None;
+                    }
+                    let _ = tokio::fs::remove_dir_all(&cleanup_dir).await;
+                    return;
+                }
                 // YT cookies aren't set yet. Two ways to land here:
                 //   1) User hasn't completed Google sign-in. Keep waiting.
                 //   2) Google sign-in succeeded but Google parked the
@@ -509,6 +880,28 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
                     }
                 }
                 continue;
+            }
+
+            if !on_music_yt && !user_confirmed {
+                if !login_ready_emitted {
+                    let _ = app_poll.emit("login-ready", ());
+                    let _ = win.set_title("Sign in — open music.youtube.com, then Continue");
+                    login_ready_emitted = true;
+                }
+                continue;
+            }
+
+            if user_confirmed && confirm_ticks >= 120 {
+                let _ = app_poll.emit(
+                    "login-failed",
+                    "Sign-in timed out. Try Import cookies from Chrome/Edge (export google.com + youtube.com).",
+                );
+                let _ = win.close();
+                if let Ok(mut guard) = app_poll.state::<LoginConfirm>().0.lock() {
+                    *guard = None;
+                }
+                let _ = tokio::fs::remove_dir_all(&cleanup_dir).await;
+                return;
             }
 
             let new_id = generate_account_id();
@@ -574,6 +967,9 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
             // single source of truth for "an account flipped" so we
             // never run the full reset twice for one login flow.
             let _ = app_poll.emit("login-success", &new_id);
+            if let Ok(mut guard) = app_poll.state::<LoginConfirm>().0.lock() {
+                *guard = None;
+            }
             let _ = win.close();
             let _ = tokio::fs::remove_dir_all(&cleanup_dir).await;
             return;
@@ -584,10 +980,38 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Whether a cookie line's domain covers `host`. Leading-dot domains and
+/// `include_subdomains=TRUE` both imply subdomain coverage (Netscape
+/// convention + what browser exporters usually intend).
+fn cookie_domain_matches(host: &str, cookie_domain: &str, include_subdomains: bool) -> bool {
+    let domain = cookie_domain.trim_start_matches('.');
+    let host_bare = host.trim_start_matches('.');
+    if host_bare == domain {
+        return true;
+    }
+    let covers_subdomains = include_subdomains || cookie_domain.starts_with('.');
+    covers_subdomains && host_bare.ends_with(&format!(".{domain}"))
+}
+
+/// Build the full `Cookie:` header InnerTube expects: every google.com and
+/// youtube.com cookie in the jar. SAPISID / PSID often live on different
+/// domains; filtering to `music.youtube.com` only drops auth tokens and
+/// yields 404s on library browse despite `is_logged_in` passing.
+async fn read_innertube_cookie_header(app: &tauri::AppHandle) -> String {
+    let Some(content) = read_cookies_plain(app).await else {
+        return String::new();
+    };
+    cookie_header_from_netscape(&content)
+}
+
 /// Parse a Netscape cookie jar and return a `Cookie:` header value
 /// containing all cookies that match the given domain (honoring the
 /// `include_subdomains` flag). Empty string if no jar or no matches.
 async fn read_cookie_header(app: &tauri::AppHandle, host: &str) -> String {
+    // InnerTube auth needs the full google+youtube jar, not host-filtered.
+    if host.contains("youtube") || host.contains("google") {
+        return read_innertube_cookie_header(app).await;
+    }
     let Some(content) = read_cookies_plain(app).await else {
         return String::new();
     };
@@ -596,21 +1020,34 @@ async fn read_cookie_header(app: &tauri::AppHandle, host: &str) -> String {
         if line.starts_with('#') || line.trim().is_empty() {
             continue;
         }
-        // domain \t include_subdomains \t path \t secure \t expiry \t name \t value
         let fields: Vec<&str> = line.split('\t').collect();
         if fields.len() < 7 {
             continue;
         }
-        let domain = fields[0].trim_start_matches('.');
         let include_sub = fields[1] == "TRUE";
-        let matches = host == domain
-            || (include_sub && host.ends_with(&format!(".{domain}")));
-        if !matches {
+        if !cookie_domain_matches(host, fields[0], include_sub) {
             continue;
         }
         parts.push(format!("{}={}", fields[5], fields[6]));
     }
     parts.join("; ")
+}
+
+#[tauri::command]
+fn cancel_login(app: tauri::AppHandle) -> Result<(), String> {
+    if let Some(win) = app.get_webview_window("login") {
+        win.close().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+async fn get_innertube_auth(app: tauri::AppHandle) -> Result<InnertubeAuthHeaders, String> {
+    let content = read_cookies_plain(&app)
+        .await
+        .ok_or_else(|| "not signed in".to_string())?;
+    build_innertube_auth_from_netscape(&content)
+        .ok_or_else(|| "missing SAPISID / PSID auth cookies".to_string())
 }
 
 #[tauri::command]
@@ -623,8 +1060,10 @@ async fn get_cookie_header(
 
 #[tauri::command]
 async fn is_logged_in(app: tauri::AppHandle) -> Result<bool, String> {
-    let header = read_cookie_header(&app, "music.youtube.com").await;
-    Ok(header.contains("SAPISID") || header.contains("__Secure-1PSID"))
+    let Some(content) = read_cookies_plain(&app).await else {
+        return Ok(false);
+    };
+    Ok(build_innertube_auth_from_netscape(&content).is_some())
 }
 
 /// Hard-exit the process. The window's close button hides into the tray
@@ -771,6 +1210,9 @@ async fn list_accounts(app: tauri::AppHandle) -> Result<Vec<AccountSummary>, Str
                 email: a.email,
                 name: a.name,
                 photo_url: a.photo_url,
+                brand_id: a.brand_id,
+                channel_name: a.channel_name,
+                channel_handle: a.channel_handle,
                 is_active,
             }
         })
@@ -1924,12 +2366,18 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .manage(state)
+        .manage(LoginConfirm::default())
         .invoke_handler(tauri::generate_handler![
             ensure_ytdlp,
             resolve_stream_ytdlp,
             get_stream_base_url,
             start_login,
+            confirm_login,
+            cancel_login,
+            import_cookies_from_text,
+            import_cookies_from_file,
             get_cookie_header,
+            get_innertube_auth,
             is_logged_in,
             clear_cookies,
             list_accounts,
@@ -1937,6 +2385,8 @@ pub fn run() {
             remove_account,
             update_account_meta,
             get_active_account_id,
+            get_active_brand_id,
+            set_active_brand,
             list_cache,
             delete_cache_entries,
             cache_cover,
@@ -1968,6 +2418,7 @@ pub fn run() {
             }
         })
         .setup(move |app| {
+            dev_server::ensure_vite_for_dev_build();
             let port = port_handle.clone();
             let token = token_handle.clone();
             let cache_root = app

--- a/src/components/auth/channel-picker-dialog.tsx
+++ b/src/components/auth/channel-picker-dialog.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Loader2Icon, TvIcon } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  fetchChannelList,
+  type BrandChannel,
+} from "@/lib/innertube/channels";
+import { cn } from "@/lib/utils";
+import { useChannelPickerAfterAuth } from "@/lib/store/accounts";
+
+type ChannelPickerDialogProps = {
+  open: boolean;
+  accountId: string | null;
+  onOpenChange: (open: boolean) => void;
+  onSelected?: () => void;
+};
+
+export function ChannelPickerDialog({
+  open,
+  accountId,
+  onOpenChange,
+  onSelected,
+}: ChannelPickerDialogProps) {
+  const [channels, setChannels] = useState<BrandChannel[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !accountId) return;
+    let cancelled = false;
+    setLoading(true);
+    void fetchChannelList()
+      .then((list) => {
+        if (!cancelled) setChannels(list);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          console.warn("[channels] fetchChannelList failed:", e);
+          toast.error("Could not load YouTube channels");
+          onOpenChange(false);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, accountId, onOpenChange]);
+
+  const selectChannel = async (channel: BrandChannel) => {
+    if (!accountId) return;
+    const key = channel.brandId ?? "primary";
+    setBusyId(key);
+    try {
+      await invoke("set_active_brand", {
+        id: accountId,
+        brandId: channel.brandId,
+        channelName: channel.channelName,
+        channelHandle: channel.channelHandle ?? null,
+      });
+      onOpenChange(false);
+      onSelected?.();
+    } catch (e) {
+      toast.error(String(e));
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <TvIcon className="size-5" />
+            Choose YouTube channel
+          </DialogTitle>
+          <DialogDescription>
+            This Google account has multiple YouTube channels. Pick which one
+            YTubic should use for your library and liked songs.
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-8 text-muted-foreground">
+            <Loader2Icon className="size-5 animate-spin" />
+          </div>
+        ) : (
+          <div className="flex max-h-72 flex-col gap-1 overflow-y-auto">
+            {channels.map((channel) => {
+              const key = channel.brandId ?? "primary";
+              const initial = channel.channelName.trim().charAt(0).toUpperCase();
+              const subtitle =
+                channel.channelHandle ||
+                (channel.brandId ? "Brand channel" : "Primary channel");
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  disabled={busyId !== null}
+                  onClick={() => void selectChannel(channel)}
+                  className={cn(
+                    "flex items-center gap-3 rounded-md px-3 py-2 text-left transition-colors",
+                    "hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                    channel.isSelected && "bg-accent/50",
+                    busyId === key && "opacity-60",
+                  )}
+                >
+                  <Avatar className="size-8 shrink-0">
+                    <AvatarFallback className="text-xs">{initial}</AvatarFallback>
+                  </Avatar>
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-medium">
+                      {channel.channelName}
+                    </div>
+                    <div className="truncate text-xs text-muted-foreground">
+                      {subtitle}
+                    </div>
+                  </div>
+                  {busyId === key ? (
+                    <Loader2Icon className="size-4 shrink-0 animate-spin" />
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function ChannelPickerHost() {
+  const { channelPickerOpen, setChannelPickerOpen, channelPickerAccountId } =
+    useChannelPickerAfterAuth();
+  return (
+    <ChannelPickerDialog
+      open={channelPickerOpen}
+      accountId={channelPickerAccountId}
+      onOpenChange={setChannelPickerOpen}
+    />
+  );
+}

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -23,8 +23,11 @@ import { usePremiumStatusSync } from "@/lib/store/premium";
 import {
   useAccountMetaBackfill,
   useAccountsChangedListener,
+  useBrandChangedListener,
   useLoginSuccessListener,
+  useLoginPolishListener,
 } from "@/lib/store/accounts";
+import { ChannelPickerHost } from "@/components/auth/channel-picker-dialog";
 import { cn } from "@/lib/utils";
 
 function isEditableTarget(el: EventTarget | null): boolean {
@@ -74,7 +77,9 @@ export function AppShell({ children }: { children: ReactNode }) {
   useUpdateStartupCheck();
   usePremiumStatusSync();
   useLoginSuccessListener();
+  useLoginPolishListener();
   useAccountsChangedListener();
+  useBrandChangedListener();
   useAccountMetaBackfill();
   useGlobalShortcuts();
   const mode = useLayoutStore((s) => s.mode);
@@ -224,6 +229,7 @@ export function AppShell({ children }: { children: ReactNode }) {
         </div>
       </SidebarProvider>
       <Toaster />
+      <ChannelPickerHost />
     </TooltipProvider>
   );
 }

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -1,4 +1,5 @@
 import { Link, useRouterState } from "@tanstack/react-router";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
@@ -18,6 +19,7 @@ import {
   LogOutIcon,
   ExternalLinkIcon,
   CheckIcon,
+  TvIcon,
 } from "lucide-react";
 import {
   Sidebar,
@@ -49,11 +51,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { usePinned, usePinnedPlaylistsStore } from "@/lib/store/pinned-playlists";
 import { fetchAccountInfo } from "@/lib/innertube/account";
+import { fetchChannelList, type BrandChannel } from "@/lib/innertube/channels";
 import { resetInnertube } from "@/lib/innertube/client";
 import { usePremiumStore } from "@/lib/store/premium";
 import {
   removeAccount,
   switchAccount,
+  setActiveBrand,
   useAccounts,
   type AccountSummary,
 } from "@/lib/store/accounts";
@@ -209,6 +213,9 @@ const MANAGE_SUBSCRIPTION_URL =
   "https://music.youtube.com/paid_memberships";
 
 function UserProfile() {
+  const [channels, setChannels] = useState<BrandChannel[]>([]);
+  const [channelsLoading, setChannelsLoading] = useState(false);
+
   const loggedIn = useQuery({
     queryKey: ["auth-logged-in"],
     queryFn: () => invoke<boolean>("is_logged_in"),
@@ -225,14 +232,55 @@ function UserProfile() {
   const premiumStatus = usePremiumStore((s) => s.status);
   const override = usePremiumStore((s) => s.override);
 
-  if (!loggedIn.data || !account.data) return null;
+  if (!loggedIn.data) return null;
 
-  const { name, email, photoUrl } = account.data;
-  const initial = (name || email || "?").trim().charAt(0).toUpperCase();
-  const isPremium = premiumStatus === "premium" || override;
-  const tierLabel = isPremium ? "Premium" : "Free";
+  const { name, email, photoUrl } = account.data ?? {
+    name: "",
+    email: "",
+    photoUrl: undefined as string | undefined,
+  };
   const allAccounts = accounts.data ?? [];
   const activeAccount = allAccounts.find((a) => a.isActive);
+  const initial = (name || email || activeAccount?.id || "?")
+    .trim()
+    .charAt(0)
+    .toUpperCase();
+  const isPremium = premiumStatus === "premium" || override;
+  const tierLabel = isPremium ? "Premium" : "Free";
+  const displayName =
+    activeAccount?.channelName || account.data?.name || "Account";
+  const displaySubtitle =
+    activeAccount?.channelHandle ||
+    (activeAccount?.channelName && account.data?.name
+      ? account.data.name
+      : null);
+
+  const loadChannels = async () => {
+    setChannelsLoading(true);
+    try {
+      const list = await fetchChannelList();
+      setChannels(list);
+    } catch (e) {
+      toast.error(String(e));
+    } finally {
+      setChannelsLoading(false);
+    }
+  };
+
+  const onSwitchChannel = (channel: BrandChannel) => async () => {
+    if (!activeAccount) return;
+    try {
+      await setActiveBrand(
+        activeAccount.id,
+        channel.brandId,
+        channel.channelName,
+        channel.channelHandle ?? null,
+      );
+      toast.success(`Switched to ${channel.channelName}`);
+    } catch (e) {
+      toast.error(String(e));
+    }
+  };
 
   const signOut = async () => {
     if (!activeAccount) {
@@ -291,19 +339,25 @@ function UserProfile() {
   return (
     <SidebarMenu>
       <SidebarMenuItem>
-        <DropdownMenu>
+        <DropdownMenu onOpenChange={(open) => open && void loadChannels()}>
           <DropdownMenuTrigger asChild>
             <SidebarMenuButton
-              tooltip={email ? `${name} — ${email}` : name}
+              tooltip={
+                displaySubtitle
+                  ? `${displayName} — ${displaySubtitle}`
+                  : email
+                    ? `${displayName} — ${email}`
+                    : displayName
+              }
               className={MENU_BTN_CLS}
             >
               <Avatar className="size-4 shrink-0">
-                {photoUrl ? <AvatarImage src={photoUrl} alt={name} /> : null}
+                {photoUrl ? <AvatarImage src={photoUrl} alt={displayName} /> : null}
                 <AvatarFallback className="text-[9px] leading-none">
                   {initial}
                 </AvatarFallback>
               </Avatar>
-              <span className="truncate">{name}</span>
+              <span className="truncate">{displayName}</span>
               <Badge
                 variant="outline"
                 className={cn(
@@ -384,6 +438,47 @@ function UserProfile() {
               <UserPlusIcon />
               Add another account
             </DropdownMenuItem>
+            <>
+              <DropdownMenuLabel className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Switch channel
+              </DropdownMenuLabel>
+              {channelsLoading ? (
+                <DropdownMenuItem disabled>Loading channels…</DropdownMenuItem>
+              ) : channels.length >= 2 ? (
+                channels.map((ch) => {
+                  const activeBrand = activeAccount?.brandId ?? null;
+                  const isActive =
+                    (ch.brandId ?? null) === activeBrand ||
+                    (!activeBrand && !ch.brandId);
+                  return (
+                    <DropdownMenuItem
+                      key={ch.brandId ?? "primary"}
+                      onSelect={onSwitchChannel(ch)}
+                    >
+                      <TvIcon />
+                      <div className="flex min-w-0 flex-col leading-tight">
+                        <span className="truncate">{ch.channelName}</span>
+                        {ch.channelHandle ? (
+                          <span className="truncate text-[10px] text-muted-foreground">
+                            {ch.channelHandle}
+                          </span>
+                        ) : null}
+                      </div>
+                      {isActive ? (
+                        <CheckIcon className="ms-auto text-emerald-500" />
+                      ) : null}
+                    </DropdownMenuItem>
+                  );
+                })
+              ) : (
+                <DropdownMenuItem disabled>
+                  {channels.length === 0
+                    ? "No channels found"
+                    : "Only one channel on this account"}
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+            </>
             <DropdownMenuItem onSelect={openExternal(MANAGE_GOOGLE_URL)}>
               <UserCogIcon />
               Manage Google Account

--- a/src/lib/innertube/channels.ts
+++ b/src/lib/innertube/channels.ts
@@ -1,0 +1,191 @@
+import { innertubePost, readRuns, type YtNode } from "./shared";
+
+
+
+export type BrandChannel = {
+
+  /** 21-digit `onBehalfOfUser` id; `null` = primary Google channel */
+
+  brandId: string | null;
+
+  channelName: string;
+
+  channelHandle?: string;
+
+  isSelected?: boolean;
+
+};
+
+
+
+const PAGE_ID_RE = /^\d{21}$/;
+
+
+
+/**
+
+ * Brand page ids live only under `selectActiveIdentityEndpoint`. A blind
+
+ * tree-walk was picking up unrelated 21-digit ids and sending a bogus
+
+ * `onBehalfOfUser`, which makes library browse return HTTP 404.
+
+ */
+
+function extractBrandPageId(item: YtNode): string | null {
+
+  const endpoint = (item.serviceEndpoint ?? item.endpoint) as YtNode | undefined;
+
+  if (!endpoint) return null;
+
+
+
+  const select =
+
+    endpoint.selectActiveIdentityEndpoint ??
+
+    (endpoint.command as YtNode | undefined)?.selectActiveIdentityEndpoint;
+
+  if (!select) return null;
+
+
+
+  const tokens = (select as YtNode).supportedTokens as YtNode[] | undefined;
+
+  if (!Array.isArray(tokens)) return null;
+
+
+
+  for (const token of tokens) {
+
+    const pageId = token?.pageIdToken?.pageId;
+
+    if (typeof pageId === "string" && PAGE_ID_RE.test(pageId)) {
+
+      return pageId;
+
+    }
+
+  }
+
+  return null;
+
+}
+
+
+
+function collectAccountItems(root: unknown): YtNode[] {
+
+  const out: YtNode[] = [];
+
+  const seen = new WeakSet<object>();
+
+  const walk = (node: unknown) => {
+
+    if (!node || typeof node !== "object") return;
+
+    if (seen.has(node as object)) return;
+
+    seen.add(node as object);
+
+
+
+    if (Array.isArray(node)) {
+
+      for (const child of node) walk(child);
+
+      return;
+
+    }
+
+
+
+    const n = node as YtNode;
+
+    if (n.accountName) {
+
+      out.push(n);
+
+      return;
+
+    }
+
+    for (const key of Object.keys(n)) walk(n[key]);
+
+  };
+
+  walk(root);
+
+  return out;
+
+}
+
+
+
+/**
+
+ * List primary + brand YouTube channels for the active cookie jar.
+
+ * Uses InnerTube `account/accounts_list` with an empty body — the
+
+ * CHANNEL_SWITCHER requestType only returns `selectText` on WEB_REMIX.
+
+ */
+
+export async function fetchChannelList(): Promise<BrandChannel[]> {
+
+  const json = await innertubePost("account/accounts_list", {});
+
+
+
+  const items = collectAccountItems(json);
+
+  const channels: BrandChannel[] = [];
+
+
+
+  for (const item of items) {
+
+    const channelName = readRuns(item.accountName);
+
+    if (!channelName) continue;
+
+    const channelHandle = readRuns(item.channelHandle) || undefined;
+
+    const brandId = extractBrandPageId(item);
+
+    channels.push({
+
+      brandId,
+
+      channelName,
+
+      channelHandle: channelHandle || undefined,
+
+      isSelected: !!item.isSelected,
+
+    });
+
+  }
+
+
+
+  // Deduplicate by brandId + name (API sometimes repeats sections).
+
+  const seen = new Set<string>();
+
+  return channels.filter((c) => {
+
+    const key = `${c.brandId ?? "primary"}:${c.channelName}`;
+
+    if (seen.has(key)) return false;
+
+    seen.add(key);
+
+    return true;
+
+  });
+
+}
+
+

--- a/src/lib/innertube/shared.ts
+++ b/src/lib/innertube/shared.ts
@@ -36,6 +36,17 @@ function saveVisitorData(value: string): void {
   }
 }
 
+/** Drop anonymous visitor id — call on sign-in/out so stale data never
+ *  rides along with authenticated cookies (causes 404 / empty library). */
+export function clearVisitorData(): void {
+  cachedVisitorData = null;
+  try {
+    window.localStorage.removeItem(VISITOR_DATA_STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
 /**
  * Walk an innertube response for `responseContext.visitorData` and update
  * our cache when present. Called from every `innertubePost` so the next
@@ -46,9 +57,9 @@ function captureVisitorData(response: YtNode): void {
   if (typeof vd === "string" && vd.length > 0) saveVisitorData(vd);
 }
 
-function buildContext(): {
+function buildContext(brandId: string | null): {
   client: Record<string, unknown>;
-  user: unknown;
+  user: Record<string, unknown>;
   request: unknown;
 } {
   const client: Record<string, unknown> = {
@@ -63,9 +74,11 @@ function buildContext(): {
   };
   const visitor = loadVisitorData();
   if (visitor) client.visitorData = visitor;
+  const user: Record<string, unknown> = { lockedSafetyMode: false };
+  if (brandId) user.onBehalfOfUser = brandId;
   return {
     client,
-    user: { lockedSafetyMode: false },
+    user,
     request: { useSsl: true },
   };
 }
@@ -86,16 +99,6 @@ const BASE_HEADERS: Record<string, string> = {
   "X-Goog-AuthUser": "0",
 };
 
-const YTM_ORIGIN = "https://music.youtube.com";
-
-async function sha1Hex(text: string): Promise<string> {
-  const buf = new TextEncoder().encode(text);
-  const hash = await crypto.subtle.digest("SHA-1", buf);
-  return Array.from(new Uint8Array(hash))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
-}
-
 // In-process cache for the cookie header. Without it every browse / search
 // / next call invokes the Rust side, which hits disk + DPAPI-decrypts the
 // jar — a 1000-track playlist scroll would do that 10+ times for no gain.
@@ -103,38 +106,65 @@ async function sha1Hex(text: string): Promise<string> {
 // dropping a fresh SID); `resetAuthCache()` is the explicit invalidation
 // path called from `resetInnertube()` after sign-in / sign-out.
 const COOKIE_CACHE_TTL_MS = 5 * 60 * 1000;
-let cookieCache: { value: string; loadedAt: number } | null = null;
-let cookiePromise: Promise<string> | null = null;
+type InnertubeAuth = { cookieHeader: string; authorization: string };
+let authCache: { value: InnertubeAuth | null; loadedAt: number } | null = null;
+let authPromise: Promise<InnertubeAuth | null> | null = null;
 // Bumped by resetAuthCache(). An in-flight load captures the epoch at start
 // and discards its result if a reset happened meanwhile — otherwise the
 // pre-reset value would be written back and served for the whole TTL after
 // a sign-in/out completes mid-fetch.
 let cookieEpoch = 0;
 
-async function loadCookieHeader(): Promise<string> {
+const BRAND_CACHE_TTL_MS = 5 * 60 * 1000;
+let brandCache: { value: string | null; loadedAt: number } | null = null;
+let brandPromise: Promise<string | null> | null = null;
+let brandEpoch = 0;
+
+async function loadActiveBrandId(): Promise<string | null> {
   const now = Date.now();
-  if (cookieCache && now - cookieCache.loadedAt < COOKIE_CACHE_TTL_MS) {
-    return cookieCache.value;
+  if (brandCache && now - brandCache.loadedAt < BRAND_CACHE_TTL_MS) {
+    return brandCache.value;
   }
-  if (cookiePromise) return cookiePromise;
-  const epoch = cookieEpoch;
-  cookiePromise = invoke<string>("get_cookie_header", {
-    host: "music.youtube.com",
-  }).then(
+  if (brandPromise) return brandPromise;
+  const epoch = brandEpoch;
+  brandPromise = invoke<string | null>("get_active_brand_id").then(
     (value) => {
-      cookiePromise = null;
-      if (epoch !== cookieEpoch) return "";
-      cookieCache = { value, loadedAt: Date.now() };
+      brandPromise = null;
+      if (epoch !== brandEpoch) return null;
+      brandCache = { value, loadedAt: Date.now() };
       return value;
     },
     () => {
-      cookiePromise = null;
-      if (epoch !== cookieEpoch) return "";
-      cookieCache = { value: "", loadedAt: Date.now() };
-      return "";
+      brandPromise = null;
+      if (epoch !== brandEpoch) return null;
+      brandCache = { value: null, loadedAt: Date.now() };
+      return null;
     },
   );
-  return cookiePromise;
+  return brandPromise;
+}
+
+async function loadInnertubeAuth(): Promise<InnertubeAuth | null> {
+  const now = Date.now();
+  if (authCache && now - authCache.loadedAt < COOKIE_CACHE_TTL_MS) {
+    return authCache.value;
+  }
+  if (authPromise) return authPromise;
+  const epoch = cookieEpoch;
+  authPromise = invoke<InnertubeAuth>("get_innertube_auth")
+    .then((value) => {
+      authPromise = null;
+      if (epoch !== cookieEpoch) return null;
+      authCache = { value, loadedAt: Date.now() };
+      return value;
+    })
+    .catch(() => {
+      authPromise = null;
+      if (epoch !== cookieEpoch) return null;
+      authCache = { value: null, loadedAt: Date.now() };
+      return null;
+    });
+  return authPromise;
 }
 
 /**
@@ -142,9 +172,13 @@ async function loadCookieHeader(): Promise<string> {
  * sign-in / sign-out so the next request re-reads the fresh jar.
  */
 export function resetAuthCache(): void {
-  cookieCache = null;
-  cookiePromise = null;
+  authCache = null;
+  authPromise = null;
   cookieEpoch++;
+  brandCache = null;
+  brandPromise = null;
+  brandEpoch++;
+  clearVisitorData();
 }
 
 /**
@@ -154,16 +188,11 @@ export function resetAuthCache(): void {
  * callers fall back to anonymous requests.
  */
 async function authHeaders(): Promise<Record<string, string>> {
-  const cookie = await loadCookieHeader();
-  if (!cookie) return {};
-  const sapisid =
-    cookie.match(/(?:^|;\s*)__Secure-3PAPISID=([^;]+)/)?.[1] ??
-    cookie.match(/(?:^|;\s*)SAPISID=([^;]+)/)?.[1];
-  const headers: Record<string, string> = { Cookie: cookie };
-  if (sapisid) {
-    const ts = Math.floor(Date.now() / 1000);
-    const hash = await sha1Hex(`${ts} ${sapisid} ${YTM_ORIGIN}`);
-    headers.Authorization = `SAPISIDHASH ${ts}_${hash}`;
+  const auth = await loadInnertubeAuth();
+  if (!auth?.cookieHeader) return {};
+  const headers: Record<string, string> = { Cookie: auth.cookieHeader };
+  if (auth.authorization) {
+    headers.Authorization = auth.authorization;
   }
   return headers;
 }
@@ -174,14 +203,22 @@ export async function innertubePost(
 ): Promise<YtNode> {
   const url = `https://music.youtube.com/youtubei/v1/${endpoint}?prettyPrint=false`;
   const auth = await authHeaders();
-  const visitor = loadVisitorData();
+  const brandId = await loadActiveBrandId();
+  // Never echo a pre-login visitor id with authenticated cookies — it
+  // can make library browse return 404 while account_menu looks fine.
+  const hasAuth = "Cookie" in auth;
+  const visitor = hasAuth ? null : loadVisitorData();
   const visitorHeader: Record<string, string> = visitor
     ? { "X-Goog-Visitor-Id": visitor }
     : {};
+  const clientContext = buildContext(brandId);
+  if (hasAuth && clientContext.client.visitorData) {
+    delete clientContext.client.visitorData;
+  }
   const res = await tauriFetch(url, {
     method: "POST",
     headers: { ...BASE_HEADERS, ...visitorHeader, ...auth },
-    body: JSON.stringify({ context: buildContext(), ...body }),
+    body: JSON.stringify({ context: clientContext, ...body }),
   });
 
   if (!res.ok) {

--- a/src/lib/store/accounts.ts
+++ b/src/lib/store/accounts.ts
@@ -1,11 +1,13 @@
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { resetInnertube } from "@/lib/innertube/client";
 import { fetchAccountInfo } from "@/lib/innertube/account";
+import { fetchChannelList } from "@/lib/innertube/channels";
 import { clearPrefetchMemo } from "@/lib/stream";
+import { toast } from "sonner";
 import { usePlaybackStore } from "@/lib/store/playback";
 import { usePinnedPlaylistsStore } from "@/lib/store/pinned-playlists";
 import { usePremiumStore } from "@/lib/store/premium";
@@ -17,6 +19,9 @@ export type AccountSummary = {
   email: string;
   name: string;
   photoUrl: string | null;
+  brandId?: string | null;
+  channelName?: string | null;
+  channelHandle?: string | null;
   isActive: boolean;
 };
 
@@ -78,6 +83,75 @@ export function useLoginSuccessListener(): void {
       void qc.invalidateQueries({ queryKey: ["active-account-id"] });
       void qc.invalidateQueries({ queryKey: ["auth-logged-in"] });
       void qc.invalidateQueries({ queryKey: ["account-info"] });
+    }).then((un) => {
+      if (cancelled) un();
+      else dispose = un;
+    });
+    return () => {
+      cancelled = true;
+      dispose?.();
+    };
+  }, [qc]);
+}
+
+/** Global toasts for embedded login polish (insecure browser, Continue). */
+export function useLoginPolishListener(): void {
+  useEffect(() => {
+    let cancelled = false;
+    const disposers: Array<() => void> = [];
+    void listen("login-insecure-browser", () => {
+      toast.error(
+        "Google blocked sign-in in the embedded window. Use Settings → Import session from browser instead.",
+        { duration: 12_000 },
+      );
+    }).then((un) => {
+      if (cancelled) un();
+      else disposers.push(un);
+    });
+    void listen("login-ready", () => {
+      toast("Sign-in cookies detected", {
+        description:
+          "Open music.youtube.com in the login window, then click Continue.",
+        action: {
+          label: "Continue",
+          onClick: () => {
+            void invoke("confirm_login").catch((e) => toast.error(String(e)));
+          },
+        },
+        duration: 20_000,
+      });
+    }).then((un) => {
+      if (cancelled) un();
+      else disposers.push(un);
+    });
+    void listen<string>("login-failed", (event) => {
+      toast.error(event.payload, { duration: 14_000 });
+    }).then((un) => {
+      if (cancelled) un();
+      else disposers.push(un);
+    });
+    return () => {
+      cancelled = true;
+      for (const d of disposers) d();
+    };
+  }, []);
+}
+
+export function useBrandChangedListener(): void {
+  const qc = useQueryClient();
+  useEffect(() => {
+    let cancelled = false;
+    let dispose: (() => void) | undefined;
+    void listen("brand-changed", () => {
+      resetInnertube();
+      void qc.invalidateQueries({ queryKey: ["accounts"] });
+      void qc.invalidateQueries({ queryKey: ["account-info"] });
+      void qc.invalidateQueries({ queryKey: ["home"] });
+      void qc.invalidateQueries({ queryKey: ["library"] });
+      void qc.invalidateQueries({ queryKey: ["liked-songs"] });
+      void qc.invalidateQueries({ queryKey: ["playlist-pages"] });
+      void qc.invalidateQueries({ queryKey: ["user-playlists"] });
+      void qc.invalidateQueries({ queryKey: ["premium-status"] });
     }).then((un) => {
       if (cancelled) un();
       else dispose = un;
@@ -221,4 +295,72 @@ export function switchAccount(id: string): Promise<void> {
 
 export function removeAccount(id: string): Promise<void> {
   return invoke<void>("remove_account", { id });
+}
+
+export function setActiveBrand(
+  id: string,
+  brandId: string | null,
+  channelName: string,
+  channelHandle?: string | null,
+): Promise<void> {
+  return invoke<void>("set_active_brand", {
+    id,
+    brandId,
+    channelName,
+    channelHandle: channelHandle ?? null,
+  });
+}
+
+/**
+ * After login or cookie import, offer a channel picker when the Google
+ * account has multiple YouTube channels (primary + brand).
+ */
+export function useChannelPickerAfterAuth(): {
+  channelPickerOpen: boolean;
+  setChannelPickerOpen: (open: boolean) => void;
+  channelPickerAccountId: string | null;
+} {
+  const [channelPickerOpen, setChannelPickerOpen] = useState(false);
+  const [channelPickerAccountId, setChannelPickerAccountId] = useState<
+    string | null
+  >(null);
+  const pendingCheck = useRef(false);
+
+  const maybeShowPicker = async (accountId: string) => {
+    if (pendingCheck.current) return;
+    pendingCheck.current = true;
+    try {
+      const channels = await fetchChannelList();
+      if (channels.length >= 2) {
+        setChannelPickerAccountId(accountId);
+        setChannelPickerOpen(true);
+      }
+    } catch (e) {
+      console.warn("[accounts] channel list check failed:", e);
+    } finally {
+      pendingCheck.current = false;
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    let dispose: (() => void) | undefined;
+    void listen<string>("login-success", (event) => {
+      const accountId = event.payload;
+      if (!accountId || cancelled) return;
+      // Brief delay so cookies + InnerTube client are ready.
+      window.setTimeout(() => {
+        if (!cancelled) void maybeShowPicker(accountId);
+      }, 800);
+    }).then((un) => {
+      if (cancelled) un();
+      else dispose = un;
+    });
+    return () => {
+      cancelled = true;
+      dispose?.();
+    };
+  }, []);
+
+  return { channelPickerOpen, setChannelPickerOpen, channelPickerAccountId };
 }

--- a/src/routes/library.tsx
+++ b/src/routes/library.tsx
@@ -220,12 +220,21 @@ function SectionsSkeleton() {
 }
 
 function ErrorCard({ message }: { message: string }) {
+  const is404 = message.includes("404") || message.includes("NOT_FOUND");
   return (
     <div className="flex items-start gap-3 rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm">
       <AlertCircleIcon className="size-5 shrink-0 text-destructive" />
       <div className="flex flex-col gap-1">
         <span className="font-medium">Couldn't load library</span>
         <span className="text-muted-foreground">{message}</span>
+        {is404 ? (
+          <span className="mt-2 text-muted-foreground">
+            If you use a brand YouTube channel, open the profile menu in the
+            sidebar and use <strong>Switch channel</strong> to pick the right
+            one. Otherwise try re-importing cookies from Chrome/Edge (include
+            both google.com and youtube.com).
+          </span>
+        ) : null}
       </div>
     </div>
   );

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -14,6 +14,9 @@ import {
   HeartIcon,
   ImageIcon,
   LockIcon,
+  CookieIcon,
+  UploadIcon,
+  AlertTriangleIcon,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -39,6 +42,9 @@ export const Route = createFileRoute("/settings")({
 
 function SettingsPage() {
   const [signingIn, setSigningIn] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [cookieText, setCookieText] = useState("");
+  const [loginReady, setLoginReady] = useState(false);
 
   const loggedIn = useQuery({
     queryKey: ["auth-logged-in"],
@@ -54,16 +60,87 @@ function SettingsPage() {
     // sidebar dropdown).
     const unlistenSuccess = listen("login-success", () => {
       setSigningIn(false);
+      setLoginReady(false);
       toast.success("Signed in");
     });
     const unlistenCancel = listen("login-cancelled", () => {
       setSigningIn(false);
+      setLoginReady(false);
+    });
+    const unlistenFailed = listen<string>("login-failed", (event) => {
+      setSigningIn(false);
+      setLoginReady(false);
+      toast.error(event.payload, { duration: 14_000 });
+    });
+    const unlistenReady = listen("login-ready", () => {
+      setLoginReady(true);
+    });
+    const unlistenInsecure = listen("login-insecure-browser", () => {
+      toast.error(
+        "Google blocked sign-in in this window. Use Import session from browser below instead.",
+        { duration: 12_000 },
+      );
     });
     return () => {
       unlistenSuccess.then((fn) => fn());
       unlistenCancel.then((fn) => fn());
+      unlistenFailed.then((fn) => fn());
+      unlistenReady.then((fn) => fn());
+      unlistenInsecure.then((fn) => fn());
     };
   }, []);
+
+  const confirmLogin = async () => {
+    try {
+      await invoke("confirm_login");
+      toast.message("Finishing sign-in…", {
+        description: "Stay on music.youtube.com in the login window.",
+      });
+    } catch (e) {
+      toast.error(String(e));
+    }
+  };
+
+  const cancelLogin = async () => {
+    try {
+      await invoke("cancel_login");
+    } catch {
+      /* window may already be closed */
+    }
+    setSigningIn(false);
+    setLoginReady(false);
+  };
+
+  const importCookies = async () => {
+    if (!cookieText.trim()) {
+      toast.error("Paste Netscape-format cookies first");
+      return;
+    }
+    setImporting(true);
+    try {
+      await invoke("import_cookies_from_text", { text: cookieText });
+      setCookieText("");
+      toast.success("Session imported");
+    } catch (e) {
+      toast.error(String(e));
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const importCookiesFromFile = async () => {
+    setImporting(true);
+    try {
+      await invoke("import_cookies_from_file");
+      toast.success("Session imported from file");
+    } catch (e) {
+      if (!String(e).includes("no file selected")) {
+        toast.error(String(e));
+      }
+    } finally {
+      setImporting(false);
+    }
+  };
 
   const signIn = async () => {
     setSigningIn(true);
@@ -135,15 +212,140 @@ function SettingsPage() {
               Sign out
             </Button>
           ) : (
-            <Button onClick={signIn} disabled={signingIn}>
-              {signingIn ? (
+            <div className="flex flex-col gap-3">
+              <Button onClick={signIn} disabled={signingIn}>
+                {signingIn ? (
+                  <Loader2Icon className="animate-spin" />
+                ) : (
+                  <LogInIcon />
+                )}
+                Sign in with Google
+              </Button>
+              {loginReady ? (
+                <div className="flex flex-col gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/5 p-3 text-sm">
+                  <p>
+                    In the login window, go to <strong>music.youtube.com</strong>{" "}
+                    and make sure you are signed in, then click Continue. YTubic
+                    will save your session and close the window.
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      size="sm"
+                      onClick={() => void confirmLogin()}
+                    >
+                      Continue
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void cancelLogin()}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : signingIn ? (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void cancelLogin()}
+                >
+                  Cancel sign-in
+                </Button>
+              ) : null}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col gap-1">
+            <CardTitle className="flex items-center gap-2">
+              <CookieIcon className="size-5" />
+              Import session from browser
+            </CardTitle>
+            <CardDescription>
+              If Google blocks the embedded sign-in window, export cookies from
+              Chrome or Edge where you are already signed in to YouTube Music.
+            </CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-sm text-muted-foreground">
+            <p className="flex items-start gap-2 font-medium text-amber-700 dark:text-amber-400">
+              <AlertTriangleIcon className="mt-0.5 size-4 shrink-0" />
+              Security warning
+            </p>
+            <p className="mt-1">
+              Pasted cookies are full account credentials. They stay encrypted
+              on this PC only — never share them or paste them into untrusted
+              sites.
+            </p>
+          </div>
+
+          <div className="text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">How to export</p>
+            <ol className="mt-2 list-decimal space-y-1 ps-5">
+              <li>
+                In Chrome or Edge, sign in at{" "}
+                <a
+                  href="https://music.youtube.com"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline"
+                >
+                  music.youtube.com
+                </a>
+              </li>
+              <li>
+                Use a Netscape cookie exporter extension (e.g. &quot;Get
+                cookies.txt LOCALLY&quot;) for <code>youtube.com</code> and{" "}
+                <code>google.com</code>
+              </li>
+              <li>Paste the file contents below or choose the exported file</li>
+            </ol>
+            <p className="mt-2">
+              Required: export cookies for both <code>youtube.com</code> and{" "}
+              <code>google.com</code> (e.g. <code>SAPISID</code>,{" "}
+              <code>__Secure-1PSID</code>, <code>LOGIN_INFO</code>).
+            </p>
+          </div>
+
+          <textarea
+            value={cookieText}
+            onChange={(e) => setCookieText(e.target.value)}
+            placeholder={"# Netscape HTTP Cookie File\n.youtube.com\tTRUE\t/\t..."}
+            rows={8}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
+            spellCheck={false}
+          />
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              onClick={() => void importCookies()}
+              disabled={importing || !cookieText.trim()}
+            >
+              {importing ? (
                 <Loader2Icon className="animate-spin" />
               ) : (
-                <LogInIcon />
+                <CookieIcon />
               )}
-              Sign in with Google
+              Import pasted cookies
             </Button>
-          )}
+            <Button
+              variant="outline"
+              onClick={() => void importCookiesFromFile()}
+              disabled={importing}
+            >
+              {importing ? (
+                <Loader2Icon className="animate-spin" />
+              ) : (
+                <UploadIcon />
+              )}
+              Choose file…
+            </Button>
+          </div>
         </CardContent>
       </Card>
 


### PR DESCRIPTION
Enable browser cookie import as a WebView login fallback, list and switch YouTube brand channels, send youtube-only cookies to InnerTube, and fix production builds with custom-protocol plus optional Vite auto-start for dev.