### PR TITLE
feat: add macOS support alongside Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,18 @@ jobs:
         run: pnpm test
 
   rust:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # macos catches cfg(target_os = "macos") regressions (Keychain
+        # secure_store, tray/Reopen); ubuntu covers the cfg(not(...)) side.
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Tauri system deps
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,20 @@
-# Builds the Windows installer and publishes a draft GitHub Release
-# whenever a `v*` tag is pushed. Publish flow:
+# Builds the Windows installer + macOS universal .dmg and publishes a
+# draft GitHub Release whenever a `v*` tag is pushed. Publish flow:
 #   git tag v0.1.0 && git push origin v0.1.0
 # → wait for this workflow → review the draft on the Releases page → publish.
+#
+# tauri-action merges both platforms' updater entries into the release's
+# single latest.json (darwin-universal + windows-x86_64 keys).
 #
 # The TAURI_SIGNING_* secrets are for tauri-plugin-updater artifact
 # signatures (latest.json + .sig). Until the updater is wired up and the
 # secrets are set, they resolve to empty strings and the build simply
 # skips updater artifacts.
+#
+# The APPLE_* secrets are for macOS code signing + notarization. They are
+# currently unset, so the .app/.dmg ship unsigned (Gatekeeper workaround
+# documented in the README). Adding the secrets later activates signing
+# automatically — no workflow change needed.
 name: Release
 
 on:
@@ -16,7 +24,15 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            args: --target universal-apple-darwin
+          - platform: windows-latest
+            args: ""
+    runs-on: ${{ matrix.platform }}
     permissions:
       contents: write
     steps:
@@ -27,6 +43,9 @@ jobs:
           node-version: 20
           cache: pnpm
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          # Universal macOS binary needs both halves; harmless empty on Windows.
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
@@ -36,9 +55,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "YTubic ${{ github.ref_name }}"
           releaseBody: "See the assets below to download and install this version."
           releaseDraft: true
           prerelease: false
+          args: ${{ matrix.args }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">YTubic</h1>
 
 <p align="center">
-  A fast, responsive YouTube Music desktop client for Windows.
+  A fast, responsive YouTube Music desktop client for Windows and macOS.
 </p>
 
 <p align="center">
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="../../releases/latest">
-    <img src="https://img.shields.io/badge/%E2%AC%87%20Download%20for%20Windows-FF0000?style=for-the-badge&logo=youtube&logoColor=white" alt="Download for Windows" height="60" />
+    <img src="https://img.shields.io/badge/%E2%AC%87%20Download%20for%20Windows%20%2F%20macOS-FF0000?style=for-the-badge&logo=youtube&logoColor=white" alt="Download for Windows / macOS" height="60" />
   </a>
 </p>
 
@@ -30,7 +30,7 @@ Built as a reaction to the sluggish webview-wrapper experience — YTubic talks 
 - **Synced lyrics** — line-by-line synced lyrics from multiple providers (LRCLIB, Musixmatch, Genius)
 - **Hi-res cover art** — upgrades album covers to high-resolution studio art when available
 - **Full library support** — your playlists, likes, albums and artists; search with filters; radio/autoplay queues
-- **Windows integration** — media keys, System Media Transport Controls, tray icon, single instance
+- **OS integration** — media keys, the system media tile (SMTC on Windows, Now Playing on macOS), tray / menu-bar icon, single instance
 - **Auto-updates** — the app updates itself from GitHub Releases, and keeps its yt-dlp copy fresh automatically
 
 > **Disclaimer:** YTubic is an unofficial client. It is not affiliated with,
@@ -41,9 +41,11 @@ Built as a reaction to the sluggish webview-wrapper experience — YTubic talks 
 
 ## Install
 
-Download the latest installer from the [Releases](../../releases) page and run it.
+Download the latest installer from the [Releases](../../releases) page and run
+it — the `.exe` on Windows, the `.dmg` on macOS.
 
-- **Windows 10/11 only** for now.
+- **Windows 10/11** and **macOS 10.15+** (Apple Silicon and Intel — the app and
+  its yt-dlp copy are universal binaries).
 - On first launch the app downloads its own copy of yt-dlp (~12 MB) into its
   data folder and keeps it updated automatically.
 - Signing in is optional: browse and playback work anonymously; sign in to get
@@ -55,6 +57,15 @@ Download the latest installer from the [Releases](../../releases) page and run i
 The installer is not code-signed (certificates are expensive for a free
 open-source project). Click "More info" → "Run anyway". The source code is
 public — you can audit it or build it yourself.
+
+**macOS says the app "is damaged" / "can't be opened" (Gatekeeper).**
+Same reason — the app is not signed or notarized. Either right-click the app
+in Applications and choose "Open" (then "Open" again), or clear the quarantine
+flag once from Terminal:
+
+```bash
+xattr -cr /Applications/YTubic.app
+```
 
 **My antivirus flags the app / yt-dlp.**
 yt-dlp is a widely-used open-source downloader that some AV vendors
@@ -74,7 +85,7 @@ yt-dlp copy every ~3 days). Restarting the app forces the check.
 
 ## Stack
 
-- **Shell:** Tauri 2 (Rust backend, system webview — WebView2 on Windows)
+- **Shell:** Tauri 2 (Rust backend, system webview — WebView2 on Windows, WKWebView on macOS)
 - **Frontend:** React 19 + TypeScript
 - **Build:** Vite 7
 - **Styling:** Tailwind CSS v4

--- a/docs/feature-roadmap.md
+++ b/docs/feature-roadmap.md
@@ -7,7 +7,7 @@
 - [ ] Queue/playlist view вместо lyrics
 - [ ] Windows controls для музыки (SMTC)
 - [ ] Linux версия
-- [ ] macOS версия
+- [x] macOS версия
 - [x] Возможность выбрать разные каналы/субпрофили для одного аккаунта
 - [ ] Auto Mix
 - [ ] Фиксы для светлой темы

--- a/docs/release-plan.md
+++ b/docs/release-plan.md
@@ -230,4 +230,4 @@ Premium-фича «загрузки»). Перед релизом:
 ### Отложено / после релиза
 - Подпись кода (Azure Trusted Signing) — когда появятся жалобы на SmartScreen
 - Fider/Canny для фидбека — если GitHub-аккаунт окажется барьером
-- macOS/Linux — потребует замены DPAPI и SMTC-слоя
+- ~~macOS~~ — готово (Keychain вместо DPAPI, Now Playing через souvlaki); Linux — потребует замены DPAPI-слоя (libsecret)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +585,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +773,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -779,6 +825,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1538,6 +1593,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2246,6 +2320,18 @@ dependencies = [
  "bitflags 2.11.1",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2535,7 +2621,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2783,6 +2869,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
@@ -3207,6 +3299,18 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3776,7 +3880,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -3804,7 +3908,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3913,6 +4017,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
 
 [[package]]
 name = "security-framework"
@@ -5545,6 +5662,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6626,8 +6753,11 @@ dependencies = [
 name = "ytubic"
 version = "0.2.2"
 dependencies = [
+ "aes-gcm",
  "axum",
  "cookie",
+ "getrandom 0.2.17",
+ "keyring",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,6 +63,14 @@ tauri-plugin-notification = "2"
 # shows up as "Unknown app". See src/media.rs.
 souvlaki = "0.7"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Cookie-jar encryption (see `mod secure_store` in lib.rs): a random data key
+# lives in the login Keychain and the jar files are AES-256-GCM under it —
+# the macOS counterpart of DPAPI below.
+keyring = { version = "3", features = ["apple-native"] }
+aes-gcm = "0.10"
+getrandom = "0.2"
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,11 +37,13 @@ fn sanitize_video_id(id: &str) -> bool {
 /// Platform-native symmetric "encrypt with current user's credentials"
 /// primitive. On Windows we use DPAPI (CryptProtectData) — the blob is
 /// only decryptable by the same Windows user on the same machine. On
-/// other platforms we currently fall back to plaintext (FIXME: hook
-/// into macOS Keychain / libsecret when we ship beyond Windows).
+/// macOS a random 256-bit data key lives in the user's login Keychain
+/// and the blobs are AES-256-GCM under it — same trust model (the OS
+/// gates access to the key by user + app). On Linux we currently fall
+/// back to plaintext (FIXME: hook into libsecret when we ship there).
 ///
-/// A fixed `ENTROPY` byte string is mixed in so a *different* app
-/// running as the same user can't trivially pass our blob to
+/// A fixed `ENTROPY` byte string is mixed in on Windows so a *different*
+/// app running as the same user can't trivially pass our blob to
 /// CryptUnprotectData and get our cookies out. This is a small hurdle
 /// against generic credential-stealer malware, not a real boundary —
 /// any attacker with our binary can read the entropy string.
@@ -126,14 +128,128 @@ mod secure_store {
         }
     }
 
-    #[cfg(not(windows))]
+    // macOS: `MAGIC ++ 12-byte nonce ++ AES-256-GCM ciphertext`, keyed by a
+    // random 32-byte data key stored in the login Keychain. Callers already
+    // run encrypt/decrypt inside `spawn_blocking`, so a Keychain permission
+    // prompt can't stall the async runtime. Note for dev: unsigned debug
+    // builds get a fresh code identity per rebuild, so macOS re-prompts for
+    // Keychain access after each rebuild — expected, goes away with a stable
+    // signing identity. Don't work around it by special-casing debug builds
+    // to plaintext.
+    #[cfg(target_os = "macos")]
+    const MAGIC: &[u8; 5] = b"YTBC1";
+
+    #[cfg(target_os = "macos")]
+    fn keychain_key() -> Result<[u8; 32], String> {
+        let entry = keyring::Entry::new("com.github.ivasy.ytubic", "cookie-store-key")
+            .map_err(|e| format!("keychain: {e}"))?;
+        match entry.get_secret() {
+            Ok(k) => k
+                .as_slice()
+                .try_into()
+                .map_err(|_| "keychain: stored key has unexpected size".into()),
+            Err(keyring::Error::NoEntry) => {
+                let mut key = [0u8; 32];
+                getrandom::getrandom(&mut key).map_err(|e| format!("getrandom: {e}"))?;
+                entry
+                    .set_secret(&key)
+                    .map_err(|e| format!("keychain: {e}"))?;
+                Ok(key)
+            }
+            Err(e) => Err(format!("keychain: {e}")),
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn seal(key: &[u8; 32], plain: &[u8]) -> Result<Vec<u8>, String> {
+        use aes_gcm::aead::{Aead, KeyInit};
+        let cipher = aes_gcm::Aes256Gcm::new(key.into());
+        let mut nonce = [0u8; 12];
+        getrandom::getrandom(&mut nonce).map_err(|e| format!("getrandom: {e}"))?;
+        let ciphertext = cipher
+            .encrypt((&nonce).into(), plain)
+            .map_err(|e| format!("encrypt: {e}"))?;
+        let mut out = Vec::with_capacity(MAGIC.len() + nonce.len() + ciphertext.len());
+        out.extend_from_slice(MAGIC);
+        out.extend_from_slice(&nonce);
+        out.extend_from_slice(&ciphertext);
+        Ok(out)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn open(key: &[u8; 32], blob: &[u8]) -> Result<Vec<u8>, String> {
+        use aes_gcm::aead::{Aead, KeyInit};
+        let body = &blob[MAGIC.len()..];
+        let (nonce, ciphertext) = body.split_at(12);
+        let cipher = aes_gcm::Aes256Gcm::new(key.into());
+        cipher
+            .decrypt(nonce.into(), ciphertext)
+            .map_err(|_| "decrypt failed (wrong key or tampered blob)".into())
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn encrypt(plain: &[u8]) -> Result<Vec<u8>, String> {
+        seal(&keychain_key()?, plain)
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn decrypt(encrypted: &[u8]) -> Result<Vec<u8>, String> {
+        // Blobs without our framing are pre-Keychain plaintext jars (or
+        // Windows DPAPI blobs on a copied profile — those fail later at the
+        // JSON parse, same as before). Pass them through: the next write
+        // re-encrypts, which is the migration path.
+        if encrypted.len() < MAGIC.len() + 12 + 16 || !encrypted.starts_with(MAGIC) {
+            return Ok(encrypted.to_vec());
+        }
+        open(&keychain_key()?, encrypted)
+    }
+
+    #[cfg(not(any(windows, target_os = "macos")))]
     pub fn encrypt(plain: &[u8]) -> Result<Vec<u8>, String> {
         Ok(plain.to_vec())
     }
 
-    #[cfg(not(windows))]
+    #[cfg(not(any(windows, target_os = "macos")))]
     pub fn decrypt(encrypted: &[u8]) -> Result<Vec<u8>, String> {
         Ok(encrypted.to_vec())
+    }
+
+    #[cfg(all(test, target_os = "macos"))]
+    mod tests {
+        // AEAD framing tests run with a fixed key so CI never touches the
+        // Keychain (headless runners can't answer the access prompt).
+        const KEY: [u8; 32] = [7u8; 32];
+
+        #[test]
+        fn roundtrip() {
+            let blob = super::seal(&KEY, b"cookie: yes").unwrap();
+            assert!(blob.starts_with(super::MAGIC));
+            assert_eq!(super::open(&KEY, &blob).unwrap(), b"cookie: yes");
+        }
+
+        #[test]
+        fn tamper_detected() {
+            let mut blob = super::seal(&KEY, b"cookie: yes").unwrap();
+            let last = blob.len() - 1;
+            blob[last] ^= 1;
+            assert!(super::open(&KEY, &blob).is_err());
+        }
+
+        #[test]
+        fn distinct_nonces() {
+            let a = super::seal(&KEY, b"same").unwrap();
+            let b = super::seal(&KEY, b"same").unwrap();
+            assert_ne!(a, b, "nonce must be random per seal");
+        }
+
+        #[test]
+        fn plaintext_passthrough() {
+            // Pre-Keychain jars have no YTBC1 framing — decrypt must hand
+            // them back untouched (and, being unframed, never hit the
+            // Keychain, so this is safe on headless CI).
+            let jar = br#"{"cookies":[]}"#;
+            assert_eq!(super::decrypt(jar).unwrap(), jar);
+        }
     }
 }
 
@@ -226,11 +342,19 @@ fn account_webview_dir(app: &tauri::AppHandle, id: &str) -> PathBuf {
     accounts_dir(app).join(id).join("webview")
 }
 
-/// Chrome UA the login and refresh WebViews both present to Google. Kept
+/// Browser UA the login and refresh WebViews both present to Google. Kept
 /// identical so the session Google issues to the login window is the
-/// same one the refresh window later renews.
+/// same one the refresh window later renews. The claimed browser must
+/// match the webview's real engine: Google fingerprints the engine and
+/// blocks sign-in on a mismatch ("This browser or app may not be
+/// secure"), so WebView2 (Chromium) claims Chrome and WKWebView (WebKit)
+/// claims Safari.
+#[cfg(not(target_os = "macos"))]
 const YT_LOGIN_UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
      (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36";
+#[cfg(target_os = "macos")]
+const YT_LOGIN_UA: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 \
+     (KHTML, like Gecko) Version/17.6 Safari/605.1.15";
 
 /// WebView2 browser args shared by the login window and the session-keeper.
 /// Both open the same per-account profile directory, and WebView2 requires
@@ -2896,7 +3020,9 @@ fn build_tray(app: &tauri::AppHandle) -> tauri::Result<()> {
             "YTubic"
         })
         .menu(&menu)
-        .show_menu_on_left_click(false)
+        // macOS menu-bar extras open their menu on left-click; on Windows
+        // left-click shows the window and the menu stays on right-click.
+        .show_menu_on_left_click(cfg!(target_os = "macos"))
         .on_menu_event(|app, event| match event.id().as_ref() {
             "show" => show_main_window(app),
             "play_pause" => {
@@ -2914,7 +3040,12 @@ fn build_tray(app: &tauri::AppHandle) -> tauri::Result<()> {
             _ => {}
         })
         .on_tray_icon_event(|tray, event| {
-            // Left-click the icon = show the window.
+            // Left-click the icon = show the window. Not on macOS, where
+            // the same click opens the menu (see show_menu_on_left_click)
+            // and the "Show YTubic" item covers restoring the window.
+            if cfg!(target_os = "macos") {
+                return;
+            }
             if let TrayIconEvent::Click {
                 button: MouseButton::Left,
                 button_state: MouseButtonState::Up,
@@ -3118,8 +3249,17 @@ pub fn run() {
             }
             Ok(())
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|_app, _event| {
+            // macOS: clicking the Dock icon while the main window is hidden
+            // (red button = hide-to-menu-bar) fires Reopen — without this
+            // handler the Dock click does nothing and the app looks hung.
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen { .. } = _event {
+                show_main_window(_app);
+            }
+        });
 }
 
 #[cfg(test)]

--- a/src-tauri/src/media.rs
+++ b/src-tauri/src/media.rs
@@ -1,6 +1,10 @@
 // OS media controls via `souvlaki`: on Windows this is the System Media
 // Transport Controls (SMTC) — the media tile in the Quick Settings / volume
-// flyout, the lock screen, and the hardware media keys.
+// flyout, the lock screen, and the hardware media keys. On macOS it's
+// MPNowPlayingInfoCenter / MPRemoteCommandCenter — the Now Playing tile in
+// Control Center and the media keys. souvlaki's macOS backend ignores
+// `PlatformConfig` entirely (no window handle needed), so the `hwnd: None`
+// path below is the correct macOS setup, not a stub.
 //
 // Why we drive this from Rust instead of the webview's `navigator.mediaSession`:
 // the audio plays in an `<audio>` element inside WebView2, so Chromium creates
@@ -25,7 +29,9 @@ use std::time::Duration;
 use souvlaki::{
     MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, MediaPosition, PlatformConfig,
 };
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter};
+#[cfg(target_os = "windows")]
+use tauri::Manager;
 
 thread_local! {
     static CONTROLS: RefCell<Option<MediaControls>> = const { RefCell::new(None) };

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "title": "YTubic",
+        "width": 1280,
+        "height": 800,
+        "minWidth": 900,
+        "minHeight": 600,
+        "decorations": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "resizable": true,
+        "center": true,
+        "backgroundColor": "#0a0a0a",
+        "dragDropEnabled": false
+      }
+    ]
+  },
+  "bundle": {
+    "targets": ["app", "dmg"],
+    "macOS": {
+      "minimumSystemVersion": "10.15"
+    }
+  }
+}

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { useLayoutStore, type LayoutMode } from "@/lib/store/layout";
+import { IS_MAC } from "@/lib/platform";
 import { openSettings } from "@/lib/store/settings-dialog";
 import { checkForUpdates } from "@/lib/updater";
 import { AboutDialog } from "@/components/layout/about-dialog";
@@ -66,10 +67,13 @@ const IS_TAURI =
   typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
 /**
- * Custom title bar. The native window frame is disabled
+ * Custom title bar. On Windows the native frame is disabled
  * (`decorations: false` in tauri.conf.json) so we draw the strip
  * ourselves: drag region down the middle, navigation controls on the
- * left, Windows-style min/maximize/close on the right.
+ * left, Windows-style min/maximize/close on the right. On macOS the
+ * native traffic lights overlay the bar (`titleBarStyle: "Overlay"` in
+ * tauri.macos.conf.json), so we skip our own buttons and pad the left
+ * cluster past them instead.
  *
  * Clicking our close button still goes through the Rust
  * `WindowEvent::CloseRequested` handler, which either hides the window
@@ -119,7 +123,9 @@ export function TopBar() {
         data-tauri-drag-region
         className="relative z-30 flex h-9 shrink-0 select-none items-center"
       >
-        <div className="flex items-center gap-1 pl-2">
+        <div
+          className={`flex items-center gap-1 ${IS_MAC ? "pl-[78px]" : "pl-2"}`}
+        >
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -196,32 +202,34 @@ export function TopBar() {
             almost anywhere in the bar to move the window. */}
         <div data-tauri-drag-region className="h-full flex-1" />
 
-        <div className="flex h-full items-center">
-          <button
-            type="button"
-            onClick={() => win().minimize()}
-            aria-label="Minimize"
-            className="flex h-full w-11 items-center justify-center text-foreground/85 transition-colors hover:bg-titlebar-hover"
-          >
-            <MinimizeGlyph />
-          </button>
-          <button
-            type="button"
-            onClick={() => win().toggleMaximize()}
-            aria-label={maximized ? "Restore" : "Maximize"}
-            className="flex h-full w-11 items-center justify-center text-foreground/85 transition-colors hover:bg-titlebar-hover"
-          >
-            {maximized ? <RestoreGlyph /> : <MaximizeGlyph />}
-          </button>
-          <button
-            type="button"
-            onClick={() => win().close()}
-            aria-label="Close"
-            className="flex h-full w-11 items-center justify-center text-foreground/85 transition-colors hover:bg-[#c42b1c] hover:text-white"
-          >
-            <CloseGlyph />
-          </button>
-        </div>
+        {!IS_MAC && (
+          <div className="flex h-full items-center">
+            <button
+              type="button"
+              onClick={() => win().minimize()}
+              aria-label="Minimize"
+              className="flex h-full w-11 items-center justify-center text-foreground/85 transition-colors hover:bg-titlebar-hover"
+            >
+              <MinimizeGlyph />
+            </button>
+            <button
+              type="button"
+              onClick={() => win().toggleMaximize()}
+              aria-label={maximized ? "Restore" : "Maximize"}
+              className="flex h-full w-11 items-center justify-center text-foreground/85 transition-colors hover:bg-titlebar-hover"
+            >
+              {maximized ? <RestoreGlyph /> : <MaximizeGlyph />}
+            </button>
+            <button
+              type="button"
+              onClick={() => win().close()}
+              aria-label="Close"
+              className="flex h-full w-11 items-center justify-center text-foreground/85 transition-colors hover:bg-[#c42b1c] hover:text-white"
+            >
+              <CloseGlyph />
+            </button>
+          </div>
+        )}
       </header>
 
       <ReportIssueDialog open={reportOpen} onOpenChange={setReportOpen} />
@@ -354,9 +362,9 @@ function ReportIssueDialog({
         <DialogHeader>
           <DialogTitle>Report an issue</DialogTitle>
           <DialogDescription>
-            Tell us what went wrong or what you'd like to see. Submitting
-            opens a prefilled GitHub issue in your browser — app version
-            and OS are attached automatically.
+            Tell us what went wrong or what you'd like to see. Submitting opens
+            a prefilled GitHub issue in your browser — app version and OS are
+            attached automatically.
           </DialogDescription>
         </DialogHeader>
 
@@ -445,11 +453,7 @@ function RestoreGlyph() {
 function CloseGlyph() {
   return (
     <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden>
-      <path
-        d="M0 0 L10 10 M10 0 L0 10"
-        stroke="currentColor"
-        strokeWidth="1"
-      />
+      <path d="M0 0 L10 10 M10 0 L0 10" stroke="currentColor" strokeWidth="1" />
     </svg>
   );
 }

--- a/src/components/settings/general-tab.tsx
+++ b/src/components/settings/general-tab.tsx
@@ -15,6 +15,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Group, SettingRow, TabPane } from "@/components/settings/primitives";
+import { IS_MAC } from "@/lib/platform";
 import { useSettingsStore } from "@/lib/store/settings";
 
 export function GeneralTab() {
@@ -90,16 +91,12 @@ function AccountGroup() {
             Not signed in
           </span>
           <span className="text-[13px] text-muted-foreground">
-            Sign in to unlock your library, liked songs, and
-            Premium-quality streams. Cookies stay on this machine.
+            Sign in to unlock your library, liked songs, and Premium-quality
+            streams. Cookies stay on this machine.
           </span>
         </div>
         <Button size="sm" onClick={signIn} disabled={signingIn}>
-          {signingIn ? (
-            <Loader2Icon className="animate-spin" />
-          ) : (
-            <LogInIcon />
-          )}
+          {signingIn ? <Loader2Icon className="animate-spin" /> : <LogInIcon />}
           Sign in with Google
         </Button>
       </div>
@@ -169,8 +166,12 @@ function BehaviorGroup() {
       />
       <SettingRow
         icon={XIcon}
-        title="Close to tray"
-        description="Hide YTubic to the tray when you press ✕ instead of quitting."
+        title={IS_MAC ? "Close to menu bar" : "Close to tray"}
+        description={
+          IS_MAC
+            ? "Hide YTubic to the menu bar when you close the window instead of quitting."
+            : "Hide YTubic to the tray when you press ✕ instead of quitting."
+        }
         control={
           <Switch
             checked={closeAction === "tray"}

--- a/src/components/shared/like-buttons.tsx
+++ b/src/components/shared/like-buttons.tsx
@@ -95,11 +95,11 @@ export function LikeDislikeButtons({
         toast.success("Added to Liked");
       }
       // The heart-fill cache (["liked-songs"]) is separate from the
-      // Library → Songs list (["library","liked-songs-pages"]) and the
+      // Library → Songs list (["library","songs-pages"]) and the
       // Liked Songs (LM) playlist page (["playlist-pages", …"LM"…]). Mark
       // those stale so they don't keep showing an outdated list. They're
       // heavy infinite queries, so invalidate only refetches if mounted.
-      void qc.invalidateQueries({ queryKey: ["library", "liked-songs-pages"] });
+      void qc.invalidateQueries({ queryKey: ["library", "songs-pages"] });
       void qc.invalidateQueries({
         predicate: (q) =>
           q.queryKey[0] === "playlist-pages" &&

--- a/src/lib/innertube/library.ts
+++ b/src/lib/innertube/library.ts
@@ -1,8 +1,12 @@
 import type { ShelfItem } from "./types";
 import {
+  collectResponsiveRows,
   collectShelfNodes,
+  findContinuationToken,
+  mapResponsiveListItem,
   mapShelfWrapper,
   rawBrowse,
+  rawBrowseContinuation,
   type YtNode,
 } from "./shared";
 
@@ -46,6 +50,44 @@ export function fetchLibraryAlbums(): Promise<LibrarySection[]> {
 
 export function fetchLibraryArtists(): Promise<LibrarySection[]> {
   return browseSections("FEmusic_library_corpus_artists");
+}
+
+/** One page of Library → Songs plus the pointer to the next. */
+export type LibrarySongsPage = {
+  tracks: ShelfItem[];
+  continuationToken?: string;
+};
+
+function collectSongRows(json: YtNode, seenIds: Set<string>): ShelfItem[] {
+  const out: ShelfItem[] = [];
+  for (const row of collectResponsiveRows(json)) {
+    const mapped = mapResponsiveListItem(row);
+    if (mapped && mapped.kind === "song" && !seenIds.has(mapped.id)) {
+      seenIds.add(mapped.id);
+      out.push(mapped);
+    }
+  }
+  return out;
+}
+
+export async function fetchLibrarySongsFirstPage(): Promise<LibrarySongsPage> {
+  const json = await rawBrowse("FEmusic_liked_videos");
+  return {
+    tracks: collectSongRows(json, new Set()),
+    continuationToken: findContinuationToken(json),
+  };
+}
+
+export async function fetchLibrarySongsContinuation(
+  token: string,
+): Promise<LibrarySongsPage> {
+  const json = await rawBrowseContinuation(token);
+  const next = findContinuationToken(json);
+  return {
+    tracks: collectSongRows(json, new Set()),
+    // A page that hands back its own token would loop forever.
+    continuationToken: next === token ? undefined : next,
+  };
 }
 
 /**

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,4 @@
+// WKWebView's user agent always contains "Mac OS X" (even the iPad-style
+// desktop UA), so a UA sniff is enough — no Tauri plugin round-trip needed.
+export const IS_MAC =
+  typeof navigator !== "undefined" && /Mac/i.test(navigator.userAgent);

--- a/src/routes/library.tsx
+++ b/src/routes/library.tsx
@@ -12,14 +12,11 @@ import {
   fetchLibraryAlbums,
   fetchLibraryArtists,
   fetchLibraryPlaylists,
+  fetchLibrarySongsContinuation,
+  fetchLibrarySongsFirstPage,
   type LibrarySection,
+  type LibrarySongsPage,
 } from "@/lib/innertube/library";
-import {
-  fetchPlaylistContinuation,
-  fetchPlaylistFirstPage,
-  type PlaylistFirstPage,
-  type PlaylistNextPage,
-} from "@/lib/innertube/playlist";
 import { openSettings } from "@/lib/store/settings-dialog";
 
 export const Route = createFileRoute("/library")({
@@ -125,15 +122,13 @@ function SectionsView({
   );
 }
 
-type AnyPage = PlaylistFirstPage | PlaylistNextPage;
-
 function LikedSongsView() {
-  const query = useInfiniteQuery<AnyPage, Error>({
-    queryKey: ["library", "liked-songs-pages"],
+  const query = useInfiniteQuery<LibrarySongsPage, Error>({
+    queryKey: ["library", "songs-pages"],
     initialPageParam: undefined,
     queryFn: async ({ pageParam }) => {
-      if (!pageParam) return fetchPlaylistFirstPage("LM");
-      return fetchPlaylistContinuation(pageParam as string);
+      if (!pageParam) return fetchLibrarySongsFirstPage();
+      return fetchLibrarySongsContinuation(pageParam as string);
     },
     getNextPageParam: (lastPage) => lastPage.continuationToken,
   });
@@ -178,7 +173,9 @@ function LikedSongsView() {
   }
   if (tracks.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground">No liked songs yet.</p>
+      <p className="text-sm text-muted-foreground">
+        No songs in your library yet.
+      </p>
     );
   }
 


### PR DESCRIPTION
## Summary

Adds first-class macOS support (Apple Silicon + Intel) while keeping Windows fully intact — all Windows code stays behind its existing `cfg(windows)` gates, NSIS keeps building, and the release workflow becomes a two-platform matrix.

Tested end-to-end on an Apple Silicon Mac (macOS 15): build, sign-in, playback, session persistence across restart, `.app`/`.dmg` bundling.

### Native window chrome
- New `src-tauri/tauri.macos.conf.json` platform overlay: native decorations with `titleBarStyle: Overlay` + hidden title. The base config (and Windows behavior) is unchanged.
- New `src/lib/platform.ts` (`IS_MAC`); the top bar skips the custom min/max/close cluster on mac and pads the left nav past the traffic lights. Drag region, close-to-tray routing, and the floating player are unchanged.

### Cookie encryption (macOS counterpart of DPAPI)
- `secure_store` gains a macOS branch: a random 32-byte data key stored in the login Keychain (`keyring` crate, `apple-native`), cookie jars framed as `YTBC1 ++ 12-byte nonce ++ AES-256-GCM` (`aes-gcm`).
- Blobs without the framing (jars written before this lands) pass through as plaintext and get re-encrypted on the next write — no migration step needed.
- The AEAD framing is unit-tested with a fixed key so CI never touches a Keychain. Windows DPAPI branch untouched; Linux keeps the plaintext fallback + FIXME.

### Google sign-in on WKWebView
- `YT_LOGIN_UA` is now platform-specific. Presenting the Chrome UA from WKWebView trips Google's "This browser or app may not be secure" block (UA contradicts the engine fingerprint); a Safari 17.6 UA matches the engine and signs in fine. Applies to both the login window and the session-keeper so the issued session is renewed under the same UA. WebView2 keeps the Chrome UA.
- Note: passkey sign-in doesn't work in WKWebView (WebAuthn needs a browser entitlement) — password sign-in works.

### Dock / menu-bar semantics
- `RunEvent::Reopen` handler restores the hidden main window on Dock-icon click (builder now goes through `.build(...)` + `.run(closure)`).
- Tray menu opens on left-click on mac (menu-bar idiom); Windows keeps left-click = show window.
- Settings copy reads "Close to menu bar" on mac.

### Media controls
- No functional change needed: souvlaki's macOS backend ignores `PlatformConfig`, so the existing `hwnd: None` path drives Now Playing / media keys. Comments updated, `Manager` import cfg-gated.

### Distribution
- macOS bundles `app` + `dmg` (`minimumSystemVersion: 10.15`); `createUpdaterArtifacts` already yields `.app.tar.gz` + `.sig`.
- `release.yml`: matrix of `macos-latest` (`--target universal-apple-darwin`) + `windows-latest`; tauri-action merges both into one `latest.json`. `APPLE_*` signing/notarization secrets are pre-wired — while unset the build ships unsigned, adding them later activates signing with no workflow change.
- `ci.yml`: rust job runs on ubuntu + macos.
- README: macOS install info + Gatekeeper first-launch FAQ (right-click → Open or `xattr -cr`).
- Good news found during the port: `yt-dlp_macos` is now a universal binary, so no Rosetta requirement on Apple Silicon.

### Library → Songs fix (platform-independent bug found while testing)
- The Songs tab fetched the auto-generated `LM` "Your Likes" playlist — the cross-YouTube likes bucket — so Shorts and regular videos liked in the YouTube app appeared in the library as songs (on Windows too).
- Switched to the dedicated library feed (`browse FEmusic_liked_videos`), which is music-only server-side and is what the official client's Songs tab reads. New `fetchLibrarySongsFirstPage` / `fetchLibrarySongsContinuation` reuse the shared row mapper and continuation machinery.
- The heart-fill cache and the "Liked Music" playlist page still read `LM`, which genuinely is the likes bucket.

## Test plan

- [x] `cargo test --lib` (12/12, incl. new AEAD round-trip/tamper/nonce/passthrough tests), `cargo check` clean on macOS
- [x] `pnpm build` (tsc + vite), eslint (no new warnings), vitest 51/51
- [x] `pnpm tauri dev` on Apple Silicon: sign-in (Safari UA), playback via yt-dlp → local stream server, session persists across restart
- [x] Library → Songs shows library songs only (no liked Shorts/videos); infinite-scroll pagination and like/unlike invalidation still work
- [x] `pnpm tauri build`: `.app` + `.dmg` + `.app.tar.gz` produced and the bundled app runs (updater signature step needs the `TAURI_SIGNING_PRIVATE_KEY` secret, as on Windows)
- [ ] Windows regression run on CI (existing rust job now also builds/tests on macos)
- [ ] Tag a test prerelease to exercise the two-platform release matrix and merged `latest.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
