### PR TITLE
Add Linux .deb and .AppImage builds to CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,15 +55,22 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Conditionally set signing keys — when the secret resolves to
-      # empty string (e.g. on a fork) Tauri still attempts to decode it
-      # and fails. Only exporting when non-empty avoids that.
-      - name: Export signing keys (if available)
+      # The updater is signed via TAURI_SIGNING_PRIVATE_KEY. When the
+      # secret is present (official repo) we export it and keep updater
+      # artifacts on. When it is absent (e.g. a fork) we both skip the
+      # empty-string key — Tauri would fail trying to decode it — and
+      # disable updater artifacts, which otherwise require the key.
+      - name: Configure signing
+        id: signing
         shell: bash
         run: |
           if [ -n "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" ]; then
             echo "TAURI_SIGNING_PRIVATE_KEY=${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" >> "$GITHUB_ENV"
             echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}" >> "$GITHUB_ENV"
+            echo "config_arg=" >> "$GITHUB_OUTPUT"
+          else
+            echo '{"bundle":{"createUpdaterArtifacts":false}}' > "$GITHUB_WORKSPACE/no-updater.json"
+            echo "config_arg=--config $GITHUB_WORKSPACE/no-updater.json" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: tauri-apps/tauri-action@v0
@@ -80,4 +87,4 @@ jobs:
           releaseBody: "See the assets below to download and install this version."
           releaseDraft: true
           prerelease: false
-          args: --bundles ${{ matrix.bundle }}
+          args: --bundles ${{ matrix.bundle }} ${{ steps.signing.outputs.config_arg }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,19 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Conditionally set signing keys — when the secret resolves to
+      # empty string (e.g. on a fork) Tauri still attempts to decode it
+      # and fails. Only exporting when non-empty avoids that.
+      - name: Export signing keys (if available)
+        run: |
+          if [ -n "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" ]; then
+            echo "TAURI_SIGNING_PRIVATE_KEY=${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" >> "$GITHUB_ENV"
+            echo "TAURI_SIGNING_PRIVATE_KEY_PASSWORD=${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}" >> "$GITHUB_ENV"
+          fi
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           # Baked into the build by src-tauri/build.rs. Add these as repo
           # Actions secrets. If unset, the released build just ships with
           # scrobbling disabled and nothing else breaks.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
-# Builds the Windows installer and publishes a draft GitHub Release
-# whenever a `v*` tag is pushed. Publish flow:
+# Builds Windows (NSIS) and Linux (.deb / .AppImage) installers and
+# publishes a draft GitHub Release whenever a `v*` tag is pushed.
+# Publish flow:
 #   git tag v0.1.0 && git push origin v0.1.0
 # → wait for this workflow → review the draft on the Releases page → publish.
 #
@@ -16,7 +17,15 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            bundle: nsis
+          - os: ubuntu-latest
+            bundle: deb,appimage
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: write
     steps:
@@ -30,7 +39,23 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+
+      - name: Install Linux system dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libssl-dev \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libayatana-appindicator3-dev
+
       - run: pnpm install --frozen-lockfile
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -47,3 +72,4 @@ jobs:
           releaseBody: "See the assets below to download and install this version."
           releaseDraft: true
           prerelease: false
+          args: --bundles ${{ matrix.bundle }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
       # empty string (e.g. on a fork) Tauri still attempts to decode it
       # and fails. Only exporting when non-empty avoids that.
       - name: Export signing keys (if available)
+        shell: bash
         run: |
           if [ -n "${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" ]; then
             echo "TAURI_SIGNING_PRIVATE_KEY=${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
-            libappindicator3-dev \
             librsvg2-dev \
             patchelf \
             libssl-dev \

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis"],
+    "targets": ["nsis", "deb", "appimage"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
@@ -39,7 +39,12 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "linux": {
+      "deb": {
+        "depends": []
+      }
+    }
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
## Summary

Adds Linux packaging to the release workflow so tagged releases produce `.deb` and `.AppImage` artifacts alongside the existing Windows NSIS installer.

## Changes

- **`src-tauri/tauri.conf.json`**: added `deb` and `appimage` to bundle `targets` and a `linux.deb` section (Tauri auto-detects shared-library dependencies).
- **`.github/workflows/release.yml`**:
  - Converted the single Windows job into a build matrix (`windows-latest` → nsis, `ubuntu-latest` → deb,appimage) with `fail-fast: false`.
  - Added Linux system dependencies (`libwebkit2gtk-4.1-dev`, `librsvg2-dev`, `patchelf`, `libssl-dev`, `libgtk-3-dev`, `libsoup-3.0-dev`, `libayatana-appindicator3-dev`).
  - Pass `--bundles` per OS so each runner builds only its supported formats.
  - Signing keys are exported only when `TAURI_SIGNING_PRIVATE_KEY` is present; on forks without the secret, updater artifacts are disabled via `--config` so the build doesn't fail trying to sign with an empty key.

## Testing

Verified on a fork run: the Ubuntu job compiled the app and produced both bundles successfully.

```
Finished 2 bundles at:
    .../bundle/deb/YTubic_0.3.2_amd64.deb
    .../bundle/appimage/YTubic_0.3.2_amd64.AppImage
```

Run: https://github.com/pedrofariasx/YTubic/actions/runs/29449913404/job/87469557857

The official repo build path is unchanged: when `TAURI_SIGNING_PRIVATE_KEY` is set, updater artifacts are still signed as before.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c43b84f1-555f-41da-b221-dfedb3e23090" />
