### PR TITLE
build: enable macOS app/dmg bundle targets

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis"],
+    "targets": ["nsis", "app", "dmg"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary
- Enable macOS `.app` / `.dmg` bundle targets alongside the existing Windows NSIS target.
- Gate the Windows-only `Manager` import so the media module compiles cleanly on non-Windows hosts.

## Context
Needed to produce macOS release builds of YTubic during local development. Small, low-risk packaging change with no runtime behavior impact on Windows.

## Test plan
- [x] `pnpm tauri build` on macOS produces `YTubic.app` and DMG
- [ ] Confirm Windows NSIS packaging still works on a Windows host