### PR TITLE
fix(playback): sync play/pause button with media keys

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7089,10 +7089,13 @@ version = "0.4.3"
 dependencies = [
  "aes-gcm",
  "axum",
+ "block",
+ "cocoa",
  "cookie",
  "discord-rich-presence",
  "keyring",
  "md5",
+ "objc",
  "rand 0.8.6",
  "reqwest 0.12.28",
  "resvg",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -121,6 +121,13 @@ rand = "0.8"
 # `PlatformWebview::inner()` returns the same type.
 webkit2gtk = "=2.0.2"
 
+# macOS: attach extra MPRemoteCommandCenter skip handlers (public MediaPlayer
+# API — no Accessibility). Versions aligned with souvlaki's macOS deps.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2"
+cocoa = "0.24"
+block = "0.1"
+
 [dev-dependencies]
 # ServiceExt::oneshot for the stream-server routing test.
 tower = { version = "0.5", features = ["util"] }

--- a/src-tauri/src/media.rs
+++ b/src-tauri/src/media.rs
@@ -1,20 +1,35 @@
-// OS media controls via `souvlaki`: on Windows this is the System Media
-// Transport Controls (SMTC) — the media tile in the Quick Settings / volume
-// flyout, the lock screen, and the hardware media keys. Linux maps to MPRIS;
-// macOS maps to Now Playing / MPRemoteCommandCenter. souvlaki does not need a
-// window handle on either platform, so `hwnd: None` is a real backend.
+// OS media controls via `souvlaki` (the supported, no-permission path):
+// - Windows: System Media Transport Controls (SMTC) — media tile, lock screen,
+//   hardware media keys.
+// - Linux: MPRIS.
+// - macOS: MPNowPlayingInfoCenter + MPRemoteCommandCenter — Control Center /
+//   lock screen / F7–F9 media keys. No Accessibility permission required.
+// souvlaki does not need a window handle on Linux/macOS, so `hwnd: None` is a
+// real backend there.
 //
-// Why we drive this from Rust instead of the webview's `navigator.mediaSession`:
-// the audio plays in an `<audio>` element inside WebView2, so Chromium creates
-// its OWN SMTC session — but that session is owned by the `msedgewebview2.exe`
-// child process, whose app identity Windows can't resolve, so the tile shows
-// "Unknown app" with no icon. There is no supported API to re-attribute a
-// WebView2 media session to the host app (WebView2Feedback #2236, open since
-// 2022). Creating the SMTC ourselves, bound to the host process's main window,
-// makes Windows resolve the tile to YTubic's own executable identity (name +
-// icon). Chromium's competing "Unknown app" tile is suppressed by disabling its
-// media session via `--disable-features=...MediaSessionService` on the main
-// window (see `additionalBrowserArgs` in tauri.conf.json).
+// macOS also uses `navigator.mediaSession` in the webview (see
+// `useAudioEngine`): once HTML <audio> is playing, WKWebView owns the Now
+// Playing session for that media, so previous/next must be registered there
+// for F7/F9 to reach us. That is still the official Media Session API —
+// not a keylogger / event tap.
+//
+// We deliberately do NOT use CGEventTap / global NSEvent monitors for media
+// keys. Those intercept HID events system-wide and trigger macOS
+// Accessibility (or Input Monitoring) prompts. Spotify/Music/etc. never do
+// that; they only register as the Now Playing target.
+//
+// Why we drive SMTC from Rust instead of the webview's `navigator.mediaSession`
+// on Windows: the audio plays in an `<audio>` element inside WebView2, so
+// Chromium creates its OWN SMTC session — but that session is owned by the
+// `msedgewebview2.exe` child process, whose app identity Windows can't resolve,
+// so the tile shows "Unknown app" with no icon. There is no supported API to
+// re-attribute a WebView2 media session to the host app (WebView2Feedback
+// #2236, open since 2022). Creating the SMTC ourselves, bound to the host
+// process's main window, makes Windows resolve the tile to YTubic's own
+// executable identity (name + icon). Chromium's competing "Unknown app" tile is
+// suppressed by disabling its media session via
+// `--disable-features=...MediaSessionService` on the main window (see
+// `additionalBrowserArgs` in tauri.conf.json).
 //
 // souvlaki's `MediaControls` is COM-backed on Windows: it is neither `Send` nor
 // `Sync`, and its calls must run on the thread that owns the window (the main
@@ -68,24 +83,7 @@ pub fn init(app: &AppHandle) {
 
     let app_handle = app.clone();
     let attached = controls.attach(move |event: MediaControlEvent| {
-        let emit = |action: &str| {
-            let _ = app_handle.emit("media-control", serde_json::json!({ "action": action }));
-        };
-        match event {
-            MediaControlEvent::Play => emit("play"),
-            MediaControlEvent::Pause => emit("pause"),
-            MediaControlEvent::Toggle => emit("toggle"),
-            MediaControlEvent::Next => emit("next"),
-            MediaControlEvent::Previous => emit("previous"),
-            MediaControlEvent::Stop => emit("stop"),
-            MediaControlEvent::SetPosition(MediaPosition(d)) => {
-                let _ = app_handle.emit(
-                    "media-control",
-                    serde_json::json!({ "action": "seek", "position": d.as_secs_f64() }),
-                );
-            }
-            _ => {}
-        }
+        emit_media_action(&app_handle, event);
     });
     if let Err(e) = attached {
         eprintln!("[media] failed to attach media controls: {e:?}");
@@ -93,6 +91,41 @@ pub fn init(app: &AppHandle) {
     }
 
     CONTROLS.with(|c| *c.borrow_mut() = Some(controls));
+
+    // souvlaki wires play/pause/previous/next. Also enable skip± so layouts
+    // that surface F7/F9 as skip (not previousTrack) still reach us — still
+    // via MPRemoteCommandCenter, no Accessibility.
+    #[cfg(target_os = "macos")]
+    macos::attach_extra_remote_commands(app.clone());
+}
+
+fn emit_media_action(app: &AppHandle, event: MediaControlEvent) {
+    let emit = |action: &str| {
+        let _ = app.emit("media-control", serde_json::json!({ "action": action }));
+    };
+    match event {
+        MediaControlEvent::Play => emit("play"),
+        MediaControlEvent::Pause => emit("pause"),
+        MediaControlEvent::Toggle => emit("toggle"),
+        MediaControlEvent::Next => emit("next"),
+        MediaControlEvent::Previous => emit("previous"),
+        MediaControlEvent::Stop => emit("stop"),
+        MediaControlEvent::Seek(dir) => match dir {
+            souvlaki::SeekDirection::Forward => emit("next"),
+            souvlaki::SeekDirection::Backward => emit("previous"),
+        },
+        MediaControlEvent::SetPosition(MediaPosition(d)) => {
+            let _ = app.emit(
+                "media-control",
+                serde_json::json!({ "action": "seek", "position": d.as_secs_f64() }),
+            );
+        }
+        _ => {}
+    }
+}
+
+fn emit_action(app: &AppHandle, action: &str) {
+    let _ = app.emit("media-control", serde_json::json!({ "action": action }));
 }
 
 /// Everything the frontend pushes about the current track. Passed as one
@@ -224,4 +257,50 @@ pub fn media_update(app: AppHandle, now: NowPlaying) {
 pub fn media_clear(app: AppHandle) {
     let handle = app.clone();
     let _ = app.run_on_main_thread(move || clear(&handle));
+}
+
+// ── macOS: extra MPRemoteCommandCenter handlers (still the public API) ──
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::emit_action;
+    use block::ConcreteBlock;
+    use cocoa::base::{id, nil, YES};
+    use objc::{class, msg_send, sel, sel_impl};
+    use tauri::AppHandle;
+
+    // MPRemoteCommandHandlerStatusSuccess
+    const MP_REMOTE_COMMAND_HANDLER_STATUS_SUCCESS: isize = 0;
+
+    /// Register skip remote commands that souvlaki does not attach.
+    /// On some macOS / keyboard layouts F7/F9 arrive as skip rather than
+    /// previousTrack/nextTrack. Map them to previous/next (music-player
+    /// semantics: restart current / next track). No Accessibility needed.
+    pub fn attach_extra_remote_commands(app: AppHandle) {
+        unsafe {
+            let command_center: id = msg_send![class!(MPRemoteCommandCenter), sharedCommandCenter];
+
+            let attach = |cmd: id, action: &'static str| {
+                if cmd == nil {
+                    return;
+                }
+                let app = app.clone();
+                let handler = ConcreteBlock::new(move |_event: id| -> isize {
+                    emit_action(&app, action);
+                    MP_REMOTE_COMMAND_HANDLER_STATUS_SUCCESS
+                })
+                .copy();
+                let _: () = msg_send![cmd, setEnabled: YES];
+                let _: () = msg_send![cmd, addTargetWithHandler: &*handler];
+                // Leak: retained by the command center for process lifetime.
+                std::mem::forget(handler);
+            };
+
+            let skip_back: id = msg_send![command_center, skipBackwardCommand];
+            let skip_fwd: id = msg_send![command_center, skipForwardCommand];
+            attach(skip_back, "previous");
+            attach(skip_fwd, "next");
+        }
+        eprintln!("[media] macOS skip remote commands attached (→ prev/next)");
+    }
 }

--- a/src/lib/audio-engine.ts
+++ b/src/lib/audio-engine.ts
@@ -39,6 +39,11 @@ export function useAudioEngine() {
   // track that keeps failing falls through to the normal error/skip path
   // instead of looping. Cleared on a successful `playing`.
   const retriedTrackRef = useRef<string | null>(null);
+  // When > 0, ignore element `play`/`pause` → store sync. Used while we
+  // intentionally pause during track switches (store still wants
+  // `playing: true`) so media-key-driven pauses stay the only ones that
+  // flip the UI.
+  const suppressPlayPauseSyncRef = useRef(0);
   // Bumping this re-runs the resolve effect for the *current* track
   // without any of its real deps changing — used to re-fetch a fresh
   // stream URL after a transient failure (e.g. a googlevideo 403).
@@ -145,12 +150,27 @@ export function useAudioEngine() {
       // buffering — keep status as ready; don't flip to loading on every gap.
     };
 
+    // Keep the play/pause button in sync when the OS / WebKit toggles the
+    // <audio> element directly (macOS media keys / F8 often do this instead
+    // of going through our souvlaki `media-control` path). Intentional
+    // pauses during track resolve are suppressed via the ref above.
+    const onPause = () => {
+      if (suppressPlayPauseSyncRef.current > 0) return;
+      if (store().playing) store().setPlaying(false);
+    };
+    const onPlay = () => {
+      if (suppressPlayPauseSyncRef.current > 0) return;
+      if (!store().playing) store().setPlaying(true);
+    };
+
     el.addEventListener("timeupdate", onTimeUpdate);
     el.addEventListener("durationchange", onDurationChange);
     el.addEventListener("ended", onEnded);
     el.addEventListener("error", onError);
     el.addEventListener("playing", onPlaying);
     el.addEventListener("waiting", onWaiting);
+    el.addEventListener("pause", onPause);
+    el.addEventListener("play", onPlay);
     return () => {
       el.removeEventListener("timeupdate", onTimeUpdate);
       el.removeEventListener("durationchange", onDurationChange);
@@ -158,6 +178,8 @@ export function useAudioEngine() {
       el.removeEventListener("error", onError);
       el.removeEventListener("playing", onPlaying);
       el.removeEventListener("waiting", onWaiting);
+      el.removeEventListener("pause", onPause);
+      el.removeEventListener("play", onPlay);
     };
   }, []);
 
@@ -190,7 +212,17 @@ export function useAudioEngine() {
     // Stop the previous track immediately. Without this the old src keeps
     // playing through the streamUrlFor() round-trip (~50–500 ms), so the
     // user hears the tail of track A bleed into the start of track B.
+    // Suppress play/pause→store sync: we still want `playing: true` so the
+    // new track auto-resumes once its src is ready. Hold the suppress for
+    // a short macrotask window — `pause` may fire async after `el.pause()`.
+    suppressPlayPauseSyncRef.current += 1;
     el.pause();
+    window.setTimeout(() => {
+      suppressPlayPauseSyncRef.current = Math.max(
+        0,
+        suppressPlayPauseSyncRef.current - 1,
+      );
+    }, 100);
     if (!streamVideoId) {
       el.removeAttribute("src");
       el.load();

--- a/src/lib/audio-engine.ts
+++ b/src/lib/audio-engine.ts
@@ -18,11 +18,18 @@ import { resolveStreamId, useTrackSourceStore } from "@/lib/store/track-source";
 import { pickThumbnail } from "@/components/shared/thumbnail";
 
 /**
- * AudioEngine binds the playback store to a singleton HTMLAudioElement and
- * drives native media controls from Rust via souvlaki (SMTC, MPRIS, and macOS
- * Now Playing; see src-tauri/src/media.rs). The webview media session stays
- * disabled on Windows because it belongs to WebView2 and appears as an
- * "Unknown app" duplicate.
+ * AudioEngine binds the playback store to a singleton HTMLAudioElement
+ * and drives OS media controls.
+ *
+ * - Windows: SMTC + hardware keys via souvlaki in Rust (see media effects and
+ *   src-tauri/src/media.rs). The webview Media Session is disabled on WebView2
+ *   so we don't get a competing "Unknown app" tile from msedgewebview2.exe.
+ * - Linux: MPRIS via souvlaki.
+ * - macOS: WKWebView claims the hardware media keys once HTML <audio> is
+ *   playing. F8 play/pause reaches the element directly; F7/F9 (previous/next,
+ *   labeled rewind/fast-forward on Mac keyboards) only fire if
+ *   `navigator.mediaSession` has action handlers. souvlaki still updates
+ *   MPNowPlayingInfoCenter for Control Center metadata.
  *
  * Mount this hook once, near the root. It owns the <audio> element's lifecycle.
  */
@@ -378,11 +385,113 @@ export function useAudioEngine() {
     }
   }, [pendingSeek]);
 
-  // OS media controls are driven from Rust via souvlaki, not
-  // navigator.mediaSession — the webview's own media session shows up as
-  // "Unknown app" because it belongs to the WebView2 child process. Metadata /
-  // state is pushed by the media_update effect lower down; buttons come back
-  // via the media-control listener. See src-tauri/src/media.rs.
+  // Media-key actions can arrive from Media Session and/or souvlaki at once
+  // on macOS. Debounce prev/next so a single physical keypress can't skip
+  // two tracks. On Windows, OS controls are driven from Rust via souvlaki
+  // (not navigator.mediaSession — that shows up as "Unknown app" on WebView2).
+  const lastSkipAtRef = useRef(0);
+  const runSkip = (dir: "prev" | "next") => {
+    const now = performance.now();
+    if (now - lastSkipAtRef.current < 250) return;
+    lastSkipAtRef.current = now;
+    const store = usePlaybackStore.getState();
+    if (dir === "prev") store.prev();
+    else store.next();
+  };
+
+  // macOS media keys (F7 previous / F9 next): WKWebView routes hardware media
+  // keys through the page Media Session while <audio> is active. Without these
+  // handlers F7/F9 often do nothing (F8 still works by toggling the element).
+  // On Windows MediaSessionService is disabled and souvlaki owns the keys —
+  // registering here is a no-op there and does not recreate the SMTC tile.
+  // Re-bind when the current track changes: WebKit sometimes drops handlers
+  // across source swaps on the <audio> element.
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !("mediaSession" in navigator)) {
+      return;
+    }
+    const ms = navigator.mediaSession;
+    const store = () => usePlaybackStore.getState();
+
+    const bind = (
+      action: MediaSessionAction,
+      handler: MediaSessionActionHandler,
+    ) => {
+      try {
+        ms.setActionHandler(action, handler);
+      } catch {
+        // Not every action is supported on every engine.
+      }
+    };
+
+    bind("play", () => store().setPlaying(true));
+    bind("pause", () => store().setPlaying(false));
+    bind("previoustrack", () => runSkip("prev"));
+    bind("nexttrack", () => runSkip("next"));
+    bind("seekto", (details) => {
+      if (typeof details.seekTime === "number") {
+        store().seek(details.seekTime);
+      }
+    });
+    // Music-player semantics for keyboard media keys: treat seek± as
+    // prev/next (restart / skip), not ±10s scrub.
+    bind("seekbackward", () => runSkip("prev"));
+    bind("seekforward", () => runSkip("next"));
+
+    return () => {
+      for (const action of [
+        "play",
+        "pause",
+        "previoustrack",
+        "nexttrack",
+        "seekto",
+        "seekbackward",
+        "seekforward",
+      ] as const) {
+        try {
+          ms.setActionHandler(action, null);
+        } catch {
+          /* ignore */
+        }
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- rebind on track identity
+  }, [track?.videoId]);
+
+  // Fallback when F7/F9 are delivered as normal function keys (System Settings
+  // → Keyboard → "Use F1, F2, etc. keys as standard function keys") or as the
+  // MediaTrack* key values some engines emit.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.repeat || e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+      const t = e.target as HTMLElement | null;
+      if (
+        t &&
+        (t.tagName === "INPUT" ||
+          t.tagName === "TEXTAREA" ||
+          t.isContentEditable)
+      ) {
+        return;
+      }
+      if (e.key === "F7" || e.key === "MediaTrackPrevious") {
+        e.preventDefault();
+        runSkip("prev");
+      } else if (e.key === "F9" || e.key === "MediaTrackNext") {
+        e.preventDefault();
+        runSkip("next");
+      } else if (e.key === "MediaPlayPause" || e.key === "F8") {
+        // F8 usually already toggles <audio>; only handle the explicit media
+        // key name so we don't fight WebKit on F8.
+        if (e.key === "MediaPlayPause") {
+          e.preventDefault();
+          usePlaybackStore.getState().toggle();
+        }
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Tray menu commands come via a Tauri event. `cancelled` flag
   // protects against StrictMode's mount→unmount→mount race that
@@ -406,10 +515,10 @@ export function useAudioEngine() {
     };
   }, []);
 
-  // System media-control / media-key button presses arrive from Rust as a
-  // `media-control` event. Drive the store the same way the old
-  // navigator.mediaSession action handlers did. `cancelled` guards against
-  // StrictMode's mount→unmount→mount double-listen, like the tray listener.
+  // SMTC / media-key button presses arrive from Rust (souvlaki /
+  // MPRemoteCommandCenter) as a `media-control` event. `cancelled` guards
+  // against StrictMode's mount→unmount→mount double-listen, like the tray
+  // listener.
   useEffect(() => {
     let cancelled = false;
     let dispose: (() => void) | undefined;
@@ -427,10 +536,10 @@ export function useAudioEngine() {
           store.toggle();
           break;
         case "next":
-          store.next();
+          runSkip("next");
           break;
         case "previous":
-          store.prev();
+          runSkip("prev");
           break;
         case "seek":
           if (typeof e.payload.position === "number")
@@ -579,12 +688,14 @@ export function useAudioEngine() {
       });
   }, [autoRadio, queueContinuation, qIndex, qLen, seedVideoId]);
 
-  // Push metadata + playback state to the OS media controls. Native backends
-  // interpolate the scrubber between pushes while the state is
-  // Playing, so we don't push on every timeupdate — just on track / play-state
-  // / duration change, plus a light 2s refresh while playing to correct drift
-  // and reflect seeks. Live values are read imperatively so this OS sync never
-  // re-triggers the resolve / playback effects above.
+  // Push metadata + playback state to the OS media controls (Windows SMTC /
+  // macOS Now Playing via souvlaki) and keep the page Media Session metadata
+  // in sync so WKWebView keeps advertising previous/next for F7/F9. Windows
+  // interpolates the scrubber between pushes while Playing, so we don't push
+  // on every timeupdate — just on track / play-state / duration change, plus a
+  // light 2s refresh while playing to correct drift and reflect seeks. Live
+  // values are read imperatively so this OS sync never re-triggers the resolve
+  // / playback effects above.
   const duration = usePlaybackStore((s) => s.duration);
   const shuffle = usePlaybackStore((s) => s.shuffle);
   const repeat = usePlaybackStore((s) => s.repeat);
@@ -601,7 +712,7 @@ export function useAudioEngine() {
   }).data;
   const liked = track ? getLikedIdsSet(likedSongs).has(track.videoId) : false;
   useEffect(() => {
-    const push = () => {
+    const pushOs = () => {
       const s = usePlaybackStore.getState();
       const t = s.index >= 0 ? s.queue[s.index] : undefined;
       if (!t) {
@@ -623,9 +734,47 @@ export function useAudioEngine() {
         },
       }).catch(() => {});
     };
-    push();
+
+    // Media Session metadata/state: only on dep change (not the 2s tick).
+    // Action handlers are registered once above; this keeps the session
+    // "live" so macOS keeps routing F7/F9 here while audio is playing.
+    if ("mediaSession" in navigator) {
+      try {
+        const s = usePlaybackStore.getState();
+        const t = s.index >= 0 ? s.queue[s.index] : undefined;
+        if (!t) {
+          navigator.mediaSession.metadata = null;
+          navigator.mediaSession.playbackState = "none";
+        } else {
+          const thumbnail = pickThumbnail(t.thumbnails, 512) ?? "";
+          navigator.mediaSession.metadata = new MediaMetadata({
+            title: t.title,
+            artist: buildArtistLabel(t),
+            album: t.album || undefined,
+            artwork: thumbnail
+              ? [{ src: thumbnail, sizes: "512x512", type: "image/jpeg" }]
+              : undefined,
+          });
+          navigator.mediaSession.playbackState = s.playing
+            ? "playing"
+            : "paused";
+          const dur = Number.isFinite(s.duration) ? s.duration : 0;
+          if (dur > 0) {
+            navigator.mediaSession.setPositionState?.({
+              duration: dur,
+              playbackRate: 1,
+              position: Math.min(Math.max(0, s.position), dur),
+            });
+          }
+        }
+      } catch {
+        /* ignore unsupported engines */
+      }
+    }
+
+    pushOs();
     if (!playing) return;
-    const id = window.setInterval(push, 2000);
+    const id = window.setInterval(pushOs, 2000);
     return () => window.clearInterval(id);
   }, [track, playing, duration, shuffle, repeat, liked]);
 


### PR DESCRIPTION
## Summary
- Keep the player play/pause icon in sync when OS media keys (e.g. macOS **F8**) toggle playback.
- On macOS, hardware media keys often pause/resume the WebKit `<audio>` element directly instead of going through the souvlaki `media-control` path, so sound changed but the store’s `playing` flag (and thus the button) did not.
- Mirror element `play` / `pause` events into the playback store.
- Briefly suppress that sync during intentional track-switch pauses so auto-advance still keeps `playing: true`.

## Test plan
- [x] Play a track, press F8 (media play/pause) — audio pauses and the player button switches to Play
- [x] Press F8 again — audio resumes and the button switches to Pause
- [x] In-app play/pause button and Space still work
- [x] Skipping tracks still auto-resumes without the button flipping to Play mid-switch
- [x] macOS release build smoke-tested

## Notes
Independent of the WEB_REMIX / auth / packaging PRs; can merge on its own against `main`.