### PR TITLE
fix(auth): tear down session-keeper WebView after cookie refresh

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1274,13 +1274,25 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
 /// it before navigating and waits for it to move.
 static KEEPER_PAGE_LOADS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-/// The live "session-keeper" WebView for `id`: a hidden window on
+/// Tear down any session-keeper WebView(s). Call after a refresh cycle so
+/// the heavy Music SPA WebContent process does not sit in RAM for the full
+/// interval between renewals — only during the short capture window.
+fn close_session_keepers(app: &tauri::AppHandle) {
+    for (label, w) in app.webview_windows() {
+        if label.starts_with("keeper-") {
+            // destroy() tears the webview down harder than close() on
+            // platforms where close is async / preventable.
+            let _ = w.destroy();
+        }
+    }
+}
+
+/// Ephemeral "session-keeper" WebView for `id`: a hidden window on
 /// music.youtube.com that reuses the account's persisted profile. As a
-/// real browser engine it stays authenticated from the stored session and
-/// keeps the server-side session (and its rotating cookies) warm, which
-/// plain HTTP replay cannot do. Built ONCE and reused; any keeper left
-/// over from a previously-active account is closed first, so at most one
-/// runs at a time. Returns (window, just_created).
+/// real browser engine it can mint / rotate the cookies that plain HTTP
+/// replay cannot. Created on demand for each refresh, then destroyed so
+/// the Music WebContent process is not resident between cycles. At most
+/// one keeper runs at a time. Returns (window, just_created).
 async fn ensure_session_keeper(
     app: &tauri::AppHandle,
     id: &str,
@@ -1293,7 +1305,7 @@ async fn ensure_session_keeper(
     // at most one keeper (the active account's) ever runs.
     for (l, w) in app.webview_windows() {
         if l.starts_with("keeper-") && l != label {
-            let _ = w.close();
+            let _ = w.destroy();
         }
     }
     if let Some(win) = app.get_webview_window(&label) {
@@ -1302,13 +1314,10 @@ async fn ensure_session_keeper(
     let url = "https://music.youtube.com/"
         .parse::<tauri::Url>()
         .map_err(|e| e.to_string())?;
-    // Hidden, undecorated, focus-less, off-screen, no taskbar entry. Built
-    // once and reused (not re-created every cycle), so there is no recurring
-    // window creation to flash on screen; the window-state plugin is told to
-    // never restore keeper windows (see `with_filter` in `run`), so a saved
-    // "visible" state can't drag it back on-screen next launch either. The
-    // webview still loads and keeps the session alive regardless of
-    // visibility or position.
+    // Hidden, undecorated, focus-less, off-screen, no taskbar entry. Lives
+    // only for the duration of one refresh cycle (see
+    // `refresh_account_cookies`). The window-state plugin never restores
+    // keeper windows (see `with_filter` in `run`).
     let win = WebviewWindowBuilder::new(app, &label, WebviewUrl::External(url))
         .title("YTubic session keeper")
         .visible(false)
@@ -1339,18 +1348,29 @@ async fn ensure_session_keeper(
     Ok((win, true))
 }
 
-/// Refresh the replayed cookie snapshot for `id` from its live session-
-/// keeper WebView. Reloads the keeper to force fresh authenticated
-/// requests (which renews the session and rotates its short-lived
-/// cookies), reads the full cookie set, and overwrites `cookies.enc`. The
-/// keeper window is left OPEN for next time.
+/// Refresh the replayed cookie snapshot for `id` from a short-lived
+/// session-keeper WebView. Spins up the keeper, reloads to force fresh
+/// authenticated traffic (which renews the session and rotates short-lived
+/// cookies), snapshots the cookie set into `cookies.enc`, then **destroys**
+/// the keeper so Music's SPA is not held in RAM between cycles.
 ///
-/// This is what survives Google's ~2h leash on *extracted* cookies: the
-/// bound browser session behind the keeper stays live, so the snapshot we
-/// replay never goes stale. Errors (leaving the existing snapshot
-/// untouched) when the account has no persisted profile or its session is
-/// logged out, so we never clobber a usable jar with an empty one.
+/// This is what survives Google's ~2h leash on *extracted* cookies: each
+/// refresh re-binds a real browser session long enough to mint a fresh jar.
+/// Errors leave the existing snapshot untouched when the account has no
+/// persisted profile or its session is logged out.
 async fn refresh_account_cookies(app: &tauri::AppHandle, id: &str) -> Result<(), String> {
+    // Always tear the keeper down when this function returns — success,
+    // error, or early exit — so a failed refresh cannot leave a 300MB+
+    // Music WebContent process around until the next cycle.
+    let result = refresh_account_cookies_inner(app, id).await;
+    close_session_keepers(app);
+    result
+}
+
+async fn refresh_account_cookies_inner(
+    app: &tauri::AppHandle,
+    id: &str,
+) -> Result<(), String> {
     // Serialize refreshes so the periodic timer and a manual trigger can't
     // reload the keeper / rewrite the jar on top of each other.
     let guard = app.state::<RefreshGuard>();
@@ -1371,7 +1391,7 @@ async fn refresh_account_cookies(app: &tauri::AppHandle, id: &str) -> Result<(),
 
     // Poll the keeper's cookie store until the full authed set is present
     // (LOGIN_INFO lands last, as at login), then snapshot it. The keeper
-    // window stays open for the next cycle.
+    // is destroyed by the outer refresh_account_cookies when we return.
     let mut captured: Option<Vec<u8>> = None;
     let mut captured_at = 0u8;
     let mut captured_count = 0usize;
@@ -1990,10 +2010,10 @@ async fn remove_account(app: tauri::AppHandle, id: String) -> Result<(), String>
         .position(|a| a.id == id)
         .ok_or_else(|| format!("no such account: {id}"))?;
     idx.accounts.remove(pos);
-    // Close this account's session-keeper (if running) so its webview
+    // Destroy this account's session-keeper (if running) so its webview
     // releases the profile directory before we delete it.
     if let Some(w) = app.get_webview_window(&format!("keeper-{id}")) {
-        let _ = w.close();
+        let _ = w.destroy();
     }
     let dir = accounts_dir(&app).join(&id);
     if dir.exists() {


### PR DESCRIPTION
## Summary
- The hidden **session-keeper** WebView (loads `music.youtube.com`) was kept open permanently so cookies could be renewed every 20 minutes.
- That leaves a full Music SPA **WebContent** process in RAM (~300MB+ on macOS), on top of the main `tauri://localhost` UI process — so a signed-in YTubic can approach a browser Music tab in memory.
- **Change:** create the keeper only for each refresh cycle, snapshot cookies, then **destroy** it (including on failure). Next cycle spins a fresh one.
- Periodic timer is unchanged (still every ~20 min, well inside Google’s ~2h extracted-cookie leash).

## Why a separate PR (not folded into #41)
- #41 is about **macOS sign-in isolation** (data stores, wipe, handoff URL).
- This is about **keeper lifecycle / RAM** and already exists on upstream `main` with the always-on keeper.
- Easier to review and merge independently; no dependency on #41.

## Tradeoffs
- Short cold cost every 20 min (open webview → load → snapshot → close) instead of a permanent ~300MB resident process.
- WebView profile on disk is unchanged; only the live window/process is torn down.

## Test plan
- [ ] Sign in, wait for first refresh (~20s after launch): Activity Monitor should show a Music/YouTube WebContent process briefly, then it should disappear
- [ ] Leave the app running >20 min: library / playback still work (cookies renewed)
- [ ] Failed refresh also tears the keeper down (no orphan process)
- [ ] Sign-out still cleans up

## Related
- Independent of #41 (macOS auth harden)
- Complements #41 if both land