### PR TITLE
feat: Add Linux support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,11 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest, ubuntu-22.04]
+    runs-on: ${{ matrix.platform }}
     permissions:
       contents: write
     steps:
@@ -30,6 +34,11 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           workspaces: src-tauri
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
       - run: pnpm install --frozen-lockfile
       - uses: tauri-apps/tauri-action@v0
         env:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">YTubic</h1>
 
 <p align="center">
-  A fast, responsive YouTube Music desktop client for Windows.
+  A fast, responsive YouTube Music desktop client for Windows and Linux.
 </p>
 
 <p align="center">
@@ -43,7 +43,7 @@ Built as a reaction to the sluggish webview-wrapper experience — YTubic talks 
 
 Download the latest installer from the [Releases](../../releases) page and run it.
 
-- **Windows 10/11 only** for now.
+- **Windows 10/11 and Linux** support.
 - On first launch the app downloads its own copy of yt-dlp (~12 MB) into its
   data folder and keeps it updated automatically.
 - Signing in is optional: browse and playback work anonymously; sign in to get

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1299,7 +1299,7 @@ async fn open_player_window(
         WebviewUrl::App("index.html?floating-player=1".into()),
     )
     .title("YTubic — player")
-    .decorations(false)
+    .decorations(true)
     .inner_size(360.0, 720.0)
     .min_inner_size(320.0, 560.0)
     .resizable(true)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    #[cfg(target_os = "linux")]
+    {
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+        std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+    }
     ytubic_lib::run()
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,7 @@
         "height": 800,
         "minWidth": 900,
         "minHeight": 600,
-        "decorations": false,
+        "decorations": true,
         "resizable": true,
         "center": true,
         "backgroundColor": "#0a0a0a",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["nsis"],
+    "targets": "all",
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
This PR adds Linux build and release targets to the GitHub Actions workflow, updates the Tauri configuration to bundle for Linux, and updates the README to reflect Linux compatibility.

It also includes fixes for known Linux WebKitGTK bugs:
- Disabled `WEBKIT_DISABLE_DMABUF_RENDERER` and `WEBKIT_DISABLE_COMPOSITING_MODE` to fix black screens and freezing on Linux (especially with NVIDIA).
- Set `decorations: true` to fix a bug where the window state manager incorrectly increases the window size on Linux when decorations are disabled.