### PR TITLE
fix(macos): make the media keys drive the queue, not just play/pause

### DIFF
--- a/src-tauri/src/media.rs
+++ b/src-tauri/src/media.rs
@@ -1,8 +1,20 @@
 // OS media controls via `souvlaki`: on Windows this is the System Media
 // Transport Controls (SMTC) — the media tile in the Quick Settings / volume
-// flyout, the lock screen, and the hardware media keys. Linux maps to MPRIS;
-// macOS maps to Now Playing / MPRemoteCommandCenter. souvlaki does not need a
-// window handle on either platform, so `hwnd: None` is a real backend.
+// flyout, the lock screen, and the hardware media keys. Linux maps to MPRIS.
+//
+// macOS deliberately does NOT go through this module. WKWebView publishes its
+// own Now Playing session as soon as an <audio> element plays, and that session
+// outranks anything we register on MPRemoteCommandCenter ourselves: WebKit
+// handles the keys internally before our commands see them. Play/pause appears
+// to work (WebKit pauses the element directly) but next/previous are dead,
+// because a bare <audio> element gives its session no such commands. Unlike
+// WebView2's `--disable-features=MediaSessionService`, WKWebView exposes no
+// switch to suppress it. So on macOS we drive that session instead of fighting
+// it — `navigator.mediaSession` supplies both the metadata and the missing
+// next/previous/seek handlers; see the IS_MAC branches in
+// src/lib/audio-engine.ts. The tile still attributes to YTubic because
+// WKWebView's media session belongs to the host process, which is exactly the
+// attribution problem Windows has and macOS doesn't.
 //
 // Why we drive this from Rust instead of the webview's `navigator.mediaSession`:
 // the audio plays in an `<audio>` element inside WebView2, so Chromium creates
@@ -25,10 +37,12 @@ use std::cell::RefCell;
 use std::time::Duration;
 
 use serde::Deserialize;
-use souvlaki::{
-    MediaControlEvent, MediaControls, MediaMetadata, MediaPlayback, MediaPosition, PlatformConfig,
-};
-use tauri::{AppHandle, Emitter, Manager};
+use souvlaki::{MediaControls, MediaMetadata, MediaPlayback, MediaPosition};
+#[cfg(not(target_os = "macos"))]
+use souvlaki::{MediaControlEvent, PlatformConfig};
+#[cfg(not(target_os = "macos"))]
+use tauri::Emitter;
+use tauri::{AppHandle, Manager};
 
 thread_local! {
     static CONTROLS: RefCell<Option<MediaControls>> = const { RefCell::new(None) };
@@ -43,56 +57,66 @@ thread_local! {
 /// Create the OS media controls and forward button presses to the frontend as
 /// a `media-control` event. MUST be called on the main thread (from `setup()`),
 /// where souvlaki requires to run and the main window's HWND is available.
+///
+/// No-op on macOS (see the module comment): leaving `CONTROLS` empty makes the
+/// souvlaki half of `apply` / `clear` below a no-op too, so the frontend owns
+/// the Now Playing session outright with no second one competing for the keys.
 pub fn init(app: &AppHandle) {
-    #[cfg(target_os = "windows")]
-    let hwnd: Option<*mut std::ffi::c_void> = app
-        .get_webview_window("main")
-        .and_then(|w| w.hwnd().ok())
-        .map(|h| h.0 as *mut std::ffi::c_void);
-    #[cfg(not(target_os = "windows"))]
-    let hwnd: Option<*mut std::ffi::c_void> = None;
+    #[cfg(target_os = "macos")]
+    let _ = app;
 
-    let config = PlatformConfig {
-        dbus_name: "ytubic",
-        display_name: "YTubic",
-        hwnd,
-    };
+    #[cfg(not(target_os = "macos"))]
+    {
+        #[cfg(target_os = "windows")]
+        let hwnd: Option<*mut std::ffi::c_void> = app
+            .get_webview_window("main")
+            .and_then(|w| w.hwnd().ok())
+            .map(|h| h.0 as *mut std::ffi::c_void);
+        #[cfg(not(target_os = "windows"))]
+        let hwnd: Option<*mut std::ffi::c_void> = None;
 
-    let mut controls = match MediaControls::new(config) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("[media] failed to create OS media controls: {e:?}");
+        let config = PlatformConfig {
+            dbus_name: "ytubic",
+            display_name: "YTubic",
+            hwnd,
+        };
+
+        let mut controls = match MediaControls::new(config) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("[media] failed to create OS media controls: {e:?}");
+                return;
+            }
+        };
+
+        let app_handle = app.clone();
+        let attached = controls.attach(move |event: MediaControlEvent| {
+            let emit = |action: &str| {
+                let _ = app_handle.emit("media-control", serde_json::json!({ "action": action }));
+            };
+            match event {
+                MediaControlEvent::Play => emit("play"),
+                MediaControlEvent::Pause => emit("pause"),
+                MediaControlEvent::Toggle => emit("toggle"),
+                MediaControlEvent::Next => emit("next"),
+                MediaControlEvent::Previous => emit("previous"),
+                MediaControlEvent::Stop => emit("stop"),
+                MediaControlEvent::SetPosition(MediaPosition(d)) => {
+                    let _ = app_handle.emit(
+                        "media-control",
+                        serde_json::json!({ "action": "seek", "position": d.as_secs_f64() }),
+                    );
+                }
+                _ => {}
+            }
+        });
+        if let Err(e) = attached {
+            eprintln!("[media] failed to attach media controls: {e:?}");
             return;
         }
-    };
 
-    let app_handle = app.clone();
-    let attached = controls.attach(move |event: MediaControlEvent| {
-        let emit = |action: &str| {
-            let _ = app_handle.emit("media-control", serde_json::json!({ "action": action }));
-        };
-        match event {
-            MediaControlEvent::Play => emit("play"),
-            MediaControlEvent::Pause => emit("pause"),
-            MediaControlEvent::Toggle => emit("toggle"),
-            MediaControlEvent::Next => emit("next"),
-            MediaControlEvent::Previous => emit("previous"),
-            MediaControlEvent::Stop => emit("stop"),
-            MediaControlEvent::SetPosition(MediaPosition(d)) => {
-                let _ = app_handle.emit(
-                    "media-control",
-                    serde_json::json!({ "action": "seek", "position": d.as_secs_f64() }),
-                );
-            }
-            _ => {}
-        }
-    });
-    if let Err(e) = attached {
-        eprintln!("[media] failed to attach media controls: {e:?}");
-        return;
+        CONTROLS.with(|c| *c.borrow_mut() = Some(controls));
     }
-
-    CONTROLS.with(|c| *c.borrow_mut() = Some(controls));
 }
 
 /// Everything the frontend pushes about the current track. Passed as one

--- a/src/lib/audio-engine.ts
+++ b/src/lib/audio-engine.ts
@@ -16,13 +16,19 @@ import { useSettingsStore } from "@/lib/store/settings";
 import { openPremiumGate } from "@/lib/store/premium-gate";
 import { resolveStreamId, useTrackSourceStore } from "@/lib/store/track-source";
 import { pickThumbnail } from "@/components/shared/thumbnail";
+import { IS_MAC } from "@/lib/platform";
 
 /**
  * AudioEngine binds the playback store to a singleton HTMLAudioElement and
- * drives native media controls from Rust via souvlaki (SMTC, MPRIS, and macOS
- * Now Playing; see src-tauri/src/media.rs). The webview media session stays
- * disabled on Windows because it belongs to WebView2 and appears as an
- * "Unknown app" duplicate.
+ * drives the native media controls.
+ *
+ * On Windows and Linux that happens from Rust via souvlaki (SMTC / MPRIS; see
+ * src-tauri/src/media.rs), and the webview's own media session stays disabled
+ * because it belongs to the WebView2 child process and appears as an "Unknown
+ * app" duplicate. macOS is the exact opposite: WKWebView's media session is the
+ * host process's own and always wins the media keys, so we feed it directly
+ * through `navigator.mediaSession` and skip souvlaki entirely — without that, a
+ * bare <audio> element leaves next/previous unhandled and the keys do nothing.
  *
  * Mount this hook once, near the root. It owns the <audio> element's lifecycle.
  */
@@ -352,6 +358,31 @@ export function useAudioEngine() {
   // state is pushed by the media_update effect lower down; buttons come back
   // via the media-control listener. See src-tauri/src/media.rs.
 
+  // macOS only: WKWebView owns the Now Playing session (see the hook comment),
+  // and the play/pause key already works because WebKit pauses the element
+  // itself — but that also means it flips `el.paused` behind the store's back,
+  // so the handlers below exist to keep the store authoritative and to supply
+  // the next/previous/seek commands a bare <audio> session simply doesn't have.
+  useEffect(() => {
+    if (!IS_MAC || !("mediaSession" in navigator)) return;
+    const ms = navigator.mediaSession;
+    const store = usePlaybackStore.getState;
+    ms.setActionHandler("play", () => store().setPlaying(true));
+    ms.setActionHandler("pause", () => store().setPlaying(false));
+    ms.setActionHandler("nexttrack", () => store().next());
+    ms.setActionHandler("previoustrack", () => store().prev());
+    ms.setActionHandler("seekto", (d) => {
+      if (typeof d.seekTime === "number") store().seek(d.seekTime);
+    });
+    return () => {
+      ms.setActionHandler("play", null);
+      ms.setActionHandler("pause", null);
+      ms.setActionHandler("nexttrack", null);
+      ms.setActionHandler("previoustrack", null);
+      ms.setActionHandler("seekto", null);
+    };
+  }, []);
+
   // Tray menu commands come via a Tauri event. `cancelled` flag
   // protects against StrictMode's mount→unmount→mount race that
   // would otherwise leak duplicate listeners and double-call
@@ -568,8 +599,53 @@ export function useAudioEngine() {
     retry: false,
   }).data;
   const liked = track ? getLikedIdsSet(likedSongs).has(track.videoId) : false;
+  // Signature of the metadata last handed to navigator.mediaSession. Re-setting
+  // `ms.metadata` makes WebKit re-fetch the artwork URL, so the 2s position
+  // refresh must not rebuild it — mirrors the LAST_META guard in media.rs.
+  const lastMacMetaRef = useRef<string | null>(null);
   useEffect(() => {
+    // macOS: same cadence, but written to the session the OS actually listens
+    // to (see the hook comment) rather than round-tripped through souvlaki.
+    const pushMac = () => {
+      const ms = navigator.mediaSession;
+      const s = usePlaybackStore.getState();
+      const t = s.index >= 0 ? s.queue[s.index] : undefined;
+      if (!t) {
+        lastMacMetaRef.current = null;
+        ms.metadata = null;
+        ms.playbackState = "none";
+        return;
+      }
+      const artist = buildArtistLabel(t);
+      const album = t.album ?? "";
+      const cover = pickThumbnail(t.thumbnails, 512) ?? "";
+      const sig = `${t.title}${artist}${album}${cover}`;
+      if (lastMacMetaRef.current !== sig) {
+        lastMacMetaRef.current = sig;
+        ms.metadata = new MediaMetadata({
+          title: t.title,
+          artist,
+          album,
+          artwork: cover ? [{ src: cover, sizes: "512x512" }] : [],
+        });
+      }
+      ms.playbackState = s.playing ? "playing" : "paused";
+      const dur = Number.isFinite(s.duration) ? s.duration : 0;
+      // setPositionState rejects a position past the duration, and a 0/absent
+      // duration outright — both happen briefly while a track is resolving.
+      if (dur > 0) {
+        ms.setPositionState({
+          duration: dur,
+          position: Math.min(Math.max(s.position, 0), dur),
+          playbackRate: 1,
+        });
+      }
+    };
     const push = () => {
+      if (IS_MAC && "mediaSession" in navigator) {
+        pushMac();
+        return;
+      }
       const s = usePlaybackStore.getState();
       const t = s.index >= 0 ? s.queue[s.index] : undefined;
       if (!t) {


### PR DESCRIPTION
## The bug

On macOS the ⏭ / ⏮ media keys do nothing. Play/pause appears to work, which is what makes this easy to miss.

## Why

`media.rs` creates the controls through souvlaki on every platform, and its macOS backend registers our handlers on `MPRemoteCommandCenter`. But WKWebView publishes **its own** Now Playing session as soon as the `<audio>` element starts, and WebKit services the hardware keys against that session before ours is consulted.

- Play/pause "works" only because WebKit pauses the element itself — our handler never runs.
- A bare `<audio>` element gives its session no `nexttrack` / `previoustrack` commands, so those keys have nothing to hit.

WebView2 has `--disable-features=MediaSessionService` (already used here for the Windows "Unknown app" tile). WKWebView has no equivalent, so the session can't be suppressed — the fix is to drive it rather than compete with it.

## The change

**`src-tauri/src/media.rs`** — `init()` becomes a no-op on macOS. `CONTROLS` stays `None`, which already makes the souvlaki half of `apply()` / `clear()` a no-op, so nothing else needed gating. **Windows and Linux paths are byte-identical**, just moved inside a `cfg(not(target_os = "macos"))` block.

**`src/lib/audio-engine.ts`** — on macOS only:
- register `play` / `pause` / `nexttrack` / `previoustrack` / `seekto` handlers on `navigator.mediaSession`
- feed that session the same metadata + position the Rust path pushes, on the same 2s cadence
- rebuild `MediaMetadata` only when the title/artist/album/cover signature changes — re-setting `metadata` makes WebKit re-fetch the artwork. Mirrors the existing `LAST_META` guard in `media.rs`.

The Control Center tile still shows **YTubic**: WKWebView's media session belongs to the host process. The attribution problem that forced the Rust-side SMTC on Windows simply doesn't exist on macOS.

## Testing

- `pnpm build` (vite + `tsc --noEmit`) — clean
- `pnpm test` — 213 passed
- `pnpm lint` — 0 errors
- `cargo check` on macOS — clean, no warnings
- Manually: ⏭ / ⏮ / play-pause on the keyboard row and in Control Center all drive the queue; the tile shows the right title, artist and cover, and the scrubber tracks.

## Scope

macOS only. No behaviour change on Windows or Linux.