### PR TITLE
perf(macos): take yt-dlp's directory build so spawns cost 0.3s, not 30s

### DIFF
--- a/src-tauri/src/ytdlp.rs
+++ b/src-tauri/src/ytdlp.rs
@@ -138,7 +138,10 @@ pub async fn ensure(app: tauri::AppHandle) {
         // Before the update check, not after: the check can spend minutes
         // re-downloading, and warming is what the next play actually waits on.
         #[cfg(target_os = "macos")]
-        prewarm(&managed);
+        {
+            prewarm(&managed);
+            sweep_legacy_onefile(&managed).await;
+        }
         maybe_self_update(&managed).await;
         return;
     }
@@ -158,7 +161,10 @@ pub async fn ensure(app: tauri::AppHandle) {
             eprintln!("[ytdlp] downloaded managed binary to {managed:?}");
             touch_update_stamp(&managed);
             #[cfg(target_os = "macos")]
-            prewarm(&managed);
+            {
+                prewarm(&managed);
+                sweep_legacy_onefile(&managed).await;
+            }
             emit_state(&app, "ready", None);
         }
         Err(e) => {
@@ -328,6 +334,27 @@ async fn extract_bundle(zip: &Path, dest: &Path) -> Result<(), String> {
 /// the background at launch moves it to a moment nobody is waiting on.
 /// When the cache is already warm this returns in a fraction of a second,
 /// so it is cheap enough to do on every launch.
+/// Delete the single-file copy that earlier versions installed.
+///
+/// An install predating the directory bundle leaves a ~36 MB `bin/yt-dlp`
+/// that nothing reads any more. Swept only once the bundle is actually in
+/// place, so an install that hasn't migrated yet keeps something runnable.
+#[cfg(target_os = "macos")]
+async fn sweep_legacy_onefile(managed: &Path) {
+    if !managed.exists() {
+        return;
+    }
+    // Can't collide with the bundle: that directory is `yt-dlp_macos`.
+    let legacy = install_root(managed).join("yt-dlp");
+    if tokio::fs::metadata(&legacy).await.is_err() {
+        return;
+    }
+    match tokio::fs::remove_file(&legacy).await {
+        Ok(()) => eprintln!("[ytdlp] removed the superseded single-file copy"),
+        Err(e) => eprintln!("[ytdlp] could not remove {legacy:?}: {e}"),
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn prewarm(managed: &Path) {
     let managed = managed.to_path_buf();

--- a/src-tauri/src/ytdlp.rs
+++ b/src-tauri/src/ytdlp.rs
@@ -1,15 +1,32 @@
 //! Managed yt-dlp binary lifecycle.
 //!
 //! End users don't have yt-dlp on PATH, so the app owns its copy: the
-//! official single-file release is downloaded into
-//! `<app-data>/bin/yt-dlp.exe` on first run and self-updated via
-//! `yt-dlp -U` on a 72-hour cadence. The managed copy is canonical —
+//! official release is downloaded into `<app-data>/bin/` on first run
+//! and refreshed on a 72-hour cadence. The managed copy is canonical —
 //! PATH is only a fallback for dev machines while the download hasn't
 //! happened (or failed).
 //!
 //! Streaming resilience depends on this: YouTube regularly breaks
 //! extractors and yt-dlp ships fixes within days, so the binary must
 //! update on its own schedule, not the app's release schedule.
+//!
+//! # Why macOS takes the directory build
+//!
+//! Windows and Linux get the single-file release. macOS deliberately does
+//! not: `yt-dlp_macos` is a PyInstaller *onefile* bundle, which unpacks
+//! its ~100 bundled dylibs into a brand-new temp directory on every single
+//! launch. Because the path is new each time, the kernel's code-signature
+//! cache never hits and dyld re-hashes every dylib from scratch — the
+//! process then sits in `fcntl` for ~30 seconds at 3% CPU before yt-dlp
+//! runs a line of its own code. That cost is paid per spawn, so it landed
+//! on every track the user played.
+//!
+//! `yt-dlp_macos.zip` is the same program built as a *directory* bundle.
+//! Its files stay on disk, so the signature check happens once and later
+//! launches start in ~0.3 s (measured: 30.0 s → 0.31 s). The trade is that
+//! yt-dlp's own updater refuses to touch a directory install ("Auto-update
+//! is not supported for unpackaged executables"), so `update_bundle` below
+//! replaces `-U` on macOS.
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -19,39 +36,69 @@ use tokio::io::AsyncWriteExt;
 
 #[cfg(windows)]
 const BINARY_NAME: &str = "yt-dlp.exe";
-#[cfg(not(windows))]
+/// The archive names its entry point after the platform, not plain `yt-dlp`.
+#[cfg(target_os = "macos")]
+const BINARY_NAME: &str = "yt-dlp_macos";
+#[cfg(all(unix, not(target_os = "macos")))]
 const BINARY_NAME: &str = "yt-dlp";
 
-/// Official single-file builds. The `latest/download/` URL redirects to
-/// the newest release asset, so no GitHub API call (and no rate limit)
-/// is involved.
+/// Directory the macOS bundle is unpacked into, under `<app-data>/bin/`.
+#[cfg(target_os = "macos")]
+const MACOS_BUNDLE_DIR: &str = "yt-dlp_macos";
+
+/// Name of the in-flight download, kept beside the install rather than
+/// inside it — on macOS the install directory itself is what gets replaced.
+#[cfg(target_os = "macos")]
+const DOWNLOAD_PART: &str = "yt-dlp_macos.zip.part";
+#[cfg(not(target_os = "macos"))]
+const DOWNLOAD_PART: &str = "yt-dlp.part";
+
+/// Official builds. The `latest/download/` URL redirects to the newest
+/// release asset, so no GitHub API call (and no rate limit) is involved.
+/// macOS takes the directory bundle — see the module comment for why.
 #[cfg(windows)]
 const DOWNLOAD_URL: &str =
     "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe";
 #[cfg(target_os = "macos")]
 const DOWNLOAD_URL: &str =
-    "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos";
+    "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos.zip";
 #[cfg(all(unix, not(target_os = "macos")))]
 const DOWNLOAD_URL: &str =
     "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp";
 
-/// How often to let the managed binary check for its own update.
+/// How often to let the managed copy check for an update.
 const UPDATE_INTERVAL: Duration = Duration::from_secs(72 * 60 * 60);
 /// Hard cap on the `-U` self-update run.
+#[cfg(not(target_os = "macos"))]
 const UPDATE_TIMEOUT: Duration = Duration::from_secs(180);
-/// Hard cap on the first-run download (the exe is ~12 MB).
+/// Hard cap on the first-run download (~12 MB single-file, ~52 MB zip).
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
-/// Where the managed binary lives for this install.
+/// Where the managed executable lives for this install. On macOS that is
+/// one level deeper than the others: the entry point inside the unpacked
+/// bundle directory.
 pub fn managed_path(app: &tauri::AppHandle) -> PathBuf {
-    app.path()
+    let dir = app
+        .path()
         .app_data_dir()
         .unwrap_or_else(|_| std::env::temp_dir())
-        .join("bin")
-        .join(BINARY_NAME)
+        .join("bin");
+    #[cfg(target_os = "macos")]
+    let dir = dir.join(MACOS_BUNDLE_DIR);
+    dir.join(BINARY_NAME)
+}
+
+/// The `bin/` directory holding the managed install and its sidecar files
+/// (the download in flight, the update stamp). One level up from the
+/// executable everywhere except macOS, where the bundle nests it twice.
+fn install_root(managed: &Path) -> &Path {
+    let root = managed.parent().unwrap_or(managed);
+    #[cfg(target_os = "macos")]
+    let root = root.parent().unwrap_or(root);
+    root
 }
 
 /// Program to spawn: the managed copy when present, otherwise bare
@@ -88,6 +135,10 @@ pub async fn ensure(app: tauri::AppHandle) {
 
     if managed.exists() {
         emit_state(&app, "ready", None);
+        // Before the update check, not after: the check can spend minutes
+        // re-downloading, and warming is what the next play actually waits on.
+        #[cfg(target_os = "macos")]
+        prewarm(&managed);
         maybe_self_update(&managed).await;
         return;
     }
@@ -106,6 +157,8 @@ pub async fn ensure(app: tauri::AppHandle) {
         Ok(()) => {
             eprintln!("[ytdlp] downloaded managed binary to {managed:?}");
             touch_update_stamp(&managed);
+            #[cfg(target_os = "macos")]
+            prewarm(&managed);
             emit_state(&app, "ready", None);
         }
         Err(e) => {
@@ -131,16 +184,16 @@ async fn probe_path_install() -> bool {
     }
 }
 
-/// Fetch the official binary into `<managed>.part`, then rename. The
-/// .part indirection means a torn download never masquerades as a
-/// working binary.
+/// Fetch the official release into a `.part` file, then put it in place.
+/// The .part indirection means a torn download never masquerades as a
+/// working install — on macOS the payload is an archive that then gets
+/// unpacked by `extract_bundle`, everywhere else it is the binary itself.
 async fn download(managed: &Path) -> Result<(), String> {
-    if let Some(dir) = managed.parent() {
-        tokio::fs::create_dir_all(dir)
-            .await
-            .map_err(|e| format!("mkdir {dir:?}: {e}"))?;
-    }
-    let part = managed.with_extension("part");
+    let root = install_root(managed);
+    tokio::fs::create_dir_all(root)
+        .await
+        .map_err(|e| format!("mkdir {root:?}: {e}"))?;
+    let part = root.join(DOWNLOAD_PART);
     let _ = tokio::fs::remove_file(&part).await;
 
     let fetch = async {
@@ -178,7 +231,7 @@ async fn download(managed: &Path) -> Result<(), String> {
         Ok(Ok(())) => {}
     }
 
-    // Sanity floor: the real exe is ~12 MB; a tiny payload is an error
+    // Sanity floor: the real payload is tens of MB; a tiny one is an error
     // page or a truncated body, not yt-dlp.
     const MIN_BINARY_BYTES: u64 = 1024 * 1024;
     let size = tokio::fs::metadata(&part)
@@ -190,23 +243,115 @@ async fn download(managed: &Path) -> Result<(), String> {
         return Err(format!("downloaded file too small ({size} bytes)"));
     }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "macos")]
     {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = tokio::fs::set_permissions(
-            &part,
-            std::fs::Permissions::from_mode(0o755),
-        )
-        .await;
+        let dest = managed.parent().unwrap_or(root);
+        let result = extract_bundle(&part, dest).await;
+        let _ = tokio::fs::remove_file(&part).await;
+        return result;
     }
 
-    tokio::fs::rename(&part, managed)
+    #[cfg(not(target_os = "macos"))]
+    {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = tokio::fs::set_permissions(
+                &part,
+                std::fs::Permissions::from_mode(0o755),
+            )
+            .await;
+        }
+
+        tokio::fs::rename(&part, managed)
+            .await
+            .map_err(|e| format!("rename: {e}"))
+    }
+}
+
+/// Unpack the release archive into `dest`, swapping it in only once the
+/// new copy is known-good, so a torn extraction can never replace a
+/// working install with a broken one.
+#[cfg(target_os = "macos")]
+async fn extract_bundle(zip: &Path, dest: &Path) -> Result<(), String> {
+    let staging = dest.with_extension("new");
+    let previous = dest.with_extension("old");
+    let _ = tokio::fs::remove_dir_all(&staging).await;
+    let _ = tokio::fs::remove_dir_all(&previous).await;
+
+    // /usr/bin/unzip ships with macOS and restores the executable bit the
+    // bundle's entry point needs, so no zip crate has to enter the tree.
+    let status = tokio::process::Command::new("/usr/bin/unzip")
+        .arg("-q")
+        .arg("-o")
+        .arg(zip)
+        .arg("-d")
+        .arg(&staging)
+        .status()
         .await
-        .map_err(|e| format!("rename: {e}"))
+        .map_err(|e| format!("spawn unzip: {e}"))?;
+    if !status.success() {
+        let _ = tokio::fs::remove_dir_all(&staging).await;
+        return Err(format!("unzip exited {status}"));
+    }
+    // An archive without the entry point is not something to install over a
+    // copy that currently works.
+    if !staging.join(BINARY_NAME).exists() {
+        let _ = tokio::fs::remove_dir_all(&staging).await;
+        return Err(format!("{BINARY_NAME} missing from the archive"));
+    }
+
+    // Move the old copy aside rather than deleting it, so a failure between
+    // the two renames can be undone instead of leaving no yt-dlp at all.
+    let had_previous = tokio::fs::metadata(dest).await.is_ok();
+    if had_previous {
+        tokio::fs::rename(dest, &previous)
+            .await
+            .map_err(|e| format!("move the old bundle aside: {e}"))?;
+    }
+    if let Err(e) = tokio::fs::rename(&staging, dest).await {
+        if had_previous {
+            let _ = tokio::fs::rename(&previous, dest).await;
+        }
+        let _ = tokio::fs::remove_dir_all(&staging).await;
+        return Err(format!("install the bundle: {e}"));
+    }
+    let _ = tokio::fs::remove_dir_all(&previous).await;
+    Ok(())
+}
+
+/// Pay the bundle's cold-start cost off the critical path.
+///
+/// The directory build is only fast once the kernel has hashed each of its
+/// dylibs, and that first pass costs ~30 s (see the module comment). Left
+/// alone it lands on whichever track the user plays first; running it in
+/// the background at launch moves it to a moment nobody is waiting on.
+/// When the cache is already warm this returns in a fraction of a second,
+/// so it is cheap enough to do on every launch.
+#[cfg(target_os = "macos")]
+fn prewarm(managed: &Path) {
+    let managed = managed.to_path_buf();
+    tokio::spawn(async move {
+        let started = std::time::Instant::now();
+        let ok = tokio::process::Command::new(&managed)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if ok {
+            eprintln!("[ytdlp] warmed in {:.1}s", started.elapsed().as_secs_f32());
+        }
+    });
 }
 
 fn update_stamp_path(managed: &Path) -> PathBuf {
-    managed.with_file_name("last-update-check")
+    // Beside the install, never inside it: on macOS the bundle directory is
+    // replaced wholesale on update, which would take the stamp with it and
+    // put the check back into a loop.
+    install_root(managed).join("last-update-check")
 }
 
 fn touch_update_stamp(managed: &Path) {
@@ -227,10 +372,9 @@ fn update_stamp_age(managed: &Path) -> Option<Duration> {
     Some(Duration::from_secs(now.saturating_sub(then)))
 }
 
-/// Run `yt-dlp -U` on the managed copy when the last check is older
-/// than `UPDATE_INTERVAL`. The official release binary replaces itself
-/// in place. The stamp is refreshed even on failure so a broken update
-/// path can't turn into a retry storm on every launch.
+/// Bring the managed copy up to date when the last check is older than
+/// `UPDATE_INTERVAL`. The stamp is refreshed even on failure so a broken
+/// update path can't turn into a retry storm on every launch.
 async fn maybe_self_update(managed: &Path) {
     match update_stamp_age(managed) {
         Some(age) if age < UPDATE_INTERVAL => return,
@@ -238,6 +382,86 @@ async fn maybe_self_update(managed: &Path) {
     }
     touch_update_stamp(managed);
 
+    #[cfg(target_os = "macos")]
+    update_bundle(managed).await;
+    #[cfg(not(target_os = "macos"))]
+    run_self_update(managed).await;
+}
+
+/// macOS replacement for `-U`: yt-dlp's updater refuses to touch a
+/// directory install ("Auto-update is not supported for unpackaged
+/// executables"), so compare the installed version against the newest
+/// release ourselves and re-install the bundle when they differ.
+#[cfg(target_os = "macos")]
+async fn update_bundle(managed: &Path) {
+    let Some(latest) = latest_release_tag().await else {
+        eprintln!("[ytdlp] could not read the latest release tag; keeping the current copy");
+        return;
+    };
+    let installed = installed_version(managed).await;
+    if installed.as_deref() == Some(latest.as_str()) {
+        return;
+    }
+    eprintln!(
+        "[ytdlp] updating {} -> {latest}",
+        installed.as_deref().unwrap_or("unknown")
+    );
+    match download(managed).await {
+        // The freshly unpacked dylibs are cold again, so warm them now
+        // rather than on the next track the user plays.
+        Ok(()) => {
+            eprintln!("[ytdlp] updated to {latest}");
+            prewarm(managed);
+        }
+        Err(e) => eprintln!("[ytdlp] update failed: {e}"),
+    }
+}
+
+/// Newest published version, read from the redirect `releases/latest`
+/// serves. One HEAD request, and unlike the GitHub API it carries no rate
+/// limit — the same reason the download URLs above go through
+/// `latest/download/`.
+#[cfg(target_os = "macos")]
+async fn latest_release_tag() -> Option<String> {
+    let resp = reqwest::Client::new()
+        .head("https://github.com/yt-dlp/yt-dlp/releases/latest")
+        .send()
+        .await
+        .ok()?
+        .error_for_status()
+        .ok()?;
+    let tag = resp.url().path().rsplit('/').next()?.trim().to_string();
+    // If the redirect ever stops landing on a version, treat it as unknown.
+    // Comparing against a non-version would re-download the bundle on every
+    // single check.
+    if !tag.starts_with(|c: char| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(tag)
+}
+
+/// Version the installed copy reports, or `None` if it won't run.
+#[cfg(target_os = "macos")]
+async fn installed_version(managed: &Path) -> Option<String> {
+    let out = tokio::process::Command::new(managed)
+        .arg("--version")
+        .output()
+        .await
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let version = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if version.is_empty() {
+        None
+    } else {
+        Some(version)
+    }
+}
+
+/// Windows / Linux: the single-file release replaces itself in place.
+#[cfg(not(target_os = "macos"))]
+async fn run_self_update(managed: &Path) {
     let mut cmd = tokio::process::Command::new(managed);
     cmd.arg("-U");
     #[cfg(windows)]
@@ -264,5 +488,98 @@ async fn maybe_self_update(managed: &Path) {
     };
     if tokio::time::timeout(UPDATE_TIMEOUT, run).await.is_err() {
         eprintln!("[ytdlp] self-update timed out");
+    }
+}
+
+/// The swap in `extract_bundle` is the one place where a bad download can
+/// destroy a working install, so it gets a test: a valid archive must
+/// replace the old bundle, and an archive missing the entry point must
+/// leave the existing one exactly as it was.
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    fn scratch(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("ytubic-ytdlp-{}-{name}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Build an archive shaped like the real one: the entry point plus an
+    /// `_internal/` payload, both at the archive root.
+    fn make_zip(root: &Path, marker: &str, with_entry_point: bool) -> PathBuf {
+        let src = root.join(format!("src-{marker}"));
+        std::fs::create_dir_all(src.join("_internal")).unwrap();
+        std::fs::write(src.join("_internal/lib.so"), marker).unwrap();
+        if with_entry_point {
+            std::fs::write(src.join(BINARY_NAME), marker).unwrap();
+        }
+        let zip = root.join(format!("{marker}.zip"));
+        let status = std::process::Command::new("/usr/bin/zip")
+            .arg("-q")
+            .arg("-r")
+            .arg(&zip)
+            .arg(".")
+            .current_dir(&src)
+            .status()
+            .unwrap();
+        assert!(status.success());
+        zip
+    }
+
+    fn entry_point_contents(dest: &Path) -> String {
+        std::fs::read_to_string(dest.join(BINARY_NAME)).unwrap()
+    }
+
+    #[test]
+    fn extract_installs_then_replaces_and_leaves_no_staging() {
+        let root = scratch("replace");
+        let dest = root.join(MACOS_BUNDLE_DIR);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        rt.block_on(extract_bundle(&make_zip(&root, "first", true), &dest))
+            .unwrap();
+        assert_eq!(entry_point_contents(&dest), "first");
+
+        rt.block_on(extract_bundle(&make_zip(&root, "second", true), &dest))
+            .unwrap();
+        assert_eq!(entry_point_contents(&dest), "second");
+        assert!(dest.join("_internal/lib.so").exists());
+
+        // Leftover staging would be silently re-used by the next extraction.
+        assert!(!dest.with_extension("new").exists());
+        assert!(!dest.with_extension("old").exists());
+    }
+
+    #[test]
+    fn archive_without_entry_point_leaves_the_working_install_alone() {
+        let root = scratch("reject");
+        let dest = root.join(MACOS_BUNDLE_DIR);
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        rt.block_on(extract_bundle(&make_zip(&root, "good", true), &dest))
+            .unwrap();
+
+        let err = rt
+            .block_on(extract_bundle(&make_zip(&root, "broken", false), &dest))
+            .unwrap_err();
+        assert!(err.contains(BINARY_NAME), "unexpected error: {err}");
+        // Still the copy that worked, not a half-installed one.
+        assert_eq!(entry_point_contents(&dest), "good");
+        assert!(!dest.with_extension("new").exists());
+    }
+
+    #[test]
+    fn install_root_is_the_bin_dir_not_the_bundle() {
+        let managed = PathBuf::from("/app-data/bin")
+            .join(MACOS_BUNDLE_DIR)
+            .join(BINARY_NAME);
+        assert_eq!(install_root(&managed), Path::new("/app-data/bin"));
+        // The update stamp has to survive the bundle being replaced.
+        assert_eq!(
+            update_stamp_path(&managed),
+            Path::new("/app-data/bin/last-update-check")
+        );
     }
 }


### PR DESCRIPTION
## The bug

On macOS, **`yt-dlp --version` takes 30 seconds.** No network, no work — just startup.

It burns 3% CPU over those 30s, so it is blocked, not computing. `sample` on the process is unambiguous:

```
Sort by top of stack, same collapsed (when >= 5):
        __fcntl  (in dyld)        4128
        mach_msg2_trap  (in dyld)   82
```

4128 of ~4200 samples in `__fcntl` inside dyld. `yt-dlp_macos` is a PyInstaller **onefile** bundle: every launch unpacks its ~100 bundled dylibs into a brand-new temp directory. Because the path is new each time, the kernel's code-signature cache never hits and dyld re-hashes every dylib from scratch. Nothing is cached between runs, so it is not a first-run cost — it is *every* run.

The app spawns yt-dlp to resolve, to download, and to prefetch, so this landed on every track. Measured breakdown of one cold play:

| Phase | Time |
|---|---|
| yt-dlp process startup | **~30 s** |
| InnerTube extraction (network) | ~4 s |
| Download a 3.4 MB track @ 1.4 MB/s | ~2.4 s |
| **Total before audio** | **~37 s** |

## The fix

yt-dlp publishes the same program as a **directory** bundle, `yt-dlp_macos.zip`. Its files stay on disk, so the signature check happens once:

```
onefile (before)   30.0s   30.0s   30.0s   30.0s     ← every launch
onedir  (after)    31.0s    0.29s   0.32s   0.31s    ← once, at install
```

A full network resolve goes from **34 s → 5.5 s**.

Windows and Linux are untouched — they keep the single-file release and `-U`.

### What changed

- **Layout.** macOS unpacks to `<app-data>/bin/yt-dlp_macos/`, and `managed_path` points at the entry point inside it. `install_root` gives the `bin/` dir for sidecar files.
- **Safe extraction.** Staging directory, entry-point check, then swap — moving the old copy aside first and restoring it if the swap fails. A torn or wrong archive can never replace a working install. `/usr/bin/unzip` does the work: it ships with macOS and restores the executable bit, so no zip crate enters the tree.
- **Update stamp** moves from beside the executable to the `bin/` root. The bundle directory is replaced wholesale on update, which would otherwise delete the stamp and put the check into a loop.
- **Updates.** yt-dlp's updater refuses a directory install:
  ```
  ERROR: Auto-update is not supported for unpackaged executables; Re-download the latest release
  ```
  So `update_bundle` replaces `-U` on macOS: read the newest version from the redirect `releases/latest` serves (one HEAD request — no GitHub API, no rate limit, same reasoning as the existing `latest/download/` URLs), compare against `--version`, re-install when they differ.
- **Pre-warm.** The one-time hashing pass still costs ~30 s after an install or update. `prewarm` runs `--version` in the background at launch so it lands on idle time instead of the user's first track. When already warm it returns in ~0.3 s, so it is cheap to do every launch.

## Testing

Three tests cover the swap — the one path where a bad download could destroy a working install:
- a valid archive installs, then a second one replaces it, leaving no `.new`/`.old` behind
- an archive missing the entry point fails **and leaves the working install byte-for-byte intact**
- `install_root` / `update_stamp_path` resolve to `bin/`, not inside the bundle

`cargo test --lib` (what CI runs): 24 passed.

Verified end to end by running the app against a fresh app-data directory:

```
[ytdlp] downloaded managed binary to .../bin/yt-dlp_macos/yt-dlp_macos
[ytdlp] warmed in 31.1s
```

Resulting layout — stamp outside the bundle, no `.part`/`.new`/`.old` residue:

```
bin/
├── last-update-check
└── yt-dlp_macos/
    ├── _internal/
    └── yt-dlp_macos
```

And every spawn since: `0.34s  0.32s  0.32s`.

## Notes for review

- The zip is ~52 MB vs ~36 MB for the onefile, so first install downloads more. It is a one-time cost, and the size floor / timeout already accommodate it.
- After each update the first spawn is slow again (~30 s) while the new dylibs are hashed. `prewarm` absorbs it; it happens at most once per 72-hour update cycle.
- `rustfmt` reports diffs in this file, but only on pre-existing lines (the `DOWNLOAD_URL` wrapping, the `set_permissions` block). The repo is not rustfmt-clean today — `build.rs` and `examples/lastfm_probe.rs` also differ — so I left those lines alone rather than mixing reformatting into the diff.