### PR TITLE
feat(album): give albums the same menus songs already have

### DIFF
--- a/src/components/shared/album-menu.tsx
+++ b/src/components/shared/album-menu.tsx
@@ -1,0 +1,216 @@
+import type { ReactNode } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  ListEndIcon,
+  ListPlusIcon,
+  MoreHorizontalIcon,
+  PlayIcon,
+  RadioIcon,
+  ShuffleIcon,
+  UserIcon,
+} from "lucide-react";
+import { toast } from "sonner";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import {
+  ctxPrimitives,
+  dropPrimitives,
+} from "@/components/shared/track-context-menu";
+import { fetchAlbum } from "@/lib/innertube/album";
+import { fetchRadio } from "@/lib/innertube/radio";
+import { usePlaybackStore } from "@/lib/store/playback";
+import type { AlbumPage, ShelfItem } from "@/lib/innertube/types";
+
+// Album rows carry no per-track thumbnail (the cover lives at the album
+// level), so backfill it before queuing — otherwise the player card and
+// background cover render empty. Same treatment the album page applies.
+function withCover(album: AlbumPage): ShelfItem[] {
+  return album.tracks.map((t) =>
+    t.thumbnails.length > 0 ? t : { ...t, thumbnails: album.thumbnails },
+  );
+}
+
+/**
+ * Shared state + handlers for both the right-click menu on an album card
+ * and the ⋯ dropdown on the album page — same split as
+ * `useTrackMenuController`, only the surrounding primitives differ.
+ *
+ * A card only knows the album's browse id, so every action resolves the
+ * track list on demand. It goes through the *same* query key the album
+ * page uses, so using this menu warms that page and vice versa. Callers
+ * that already hold the page (the album route) pass it in and skip the
+ * fetch entirely.
+ */
+export function useAlbumMenuController(albumId: string, album?: AlbumPage) {
+  const qc = useQueryClient();
+  const navigate = useNavigate();
+
+  const resolve = async (): Promise<AlbumPage | null> => {
+    if (album) return album;
+    try {
+      return await qc.fetchQuery({
+        queryKey: ["album", albumId],
+        queryFn: () => fetchAlbum(albumId),
+        staleTime: 5 * 60_000,
+      });
+    } catch (e) {
+      toast.error(`Couldn't load album: ${String(e)}`);
+      return null;
+    }
+  };
+
+  const play = async (shuffle: boolean) => {
+    const a = await resolve();
+    if (!a) return;
+    const items = withCover(a);
+    if (items.length === 0) return;
+    const store = usePlaybackStore.getState();
+    store.playShelfItems(
+      items,
+      shuffle ? Math.floor(Math.random() * items.length) : 0,
+    );
+    store.setShuffle(shuffle);
+  };
+
+  const playNext = async () => {
+    const a = await resolve();
+    if (!a) return;
+    const items = withCover(a);
+    if (items.length === 0) return;
+    // enqueueNext always inserts directly after the current track, so
+    // walking the album backwards leaves it in album order.
+    for (const t of [...items].reverse()) {
+      usePlaybackStore.getState().enqueueNext(t);
+    }
+    toast.success(`Playing next: ${a.title}`);
+  };
+
+  const addToQueue = async () => {
+    const a = await resolve();
+    if (!a) return;
+    const items = withCover(a);
+    if (items.length === 0) return;
+    usePlaybackStore.getState().appendToQueue(items);
+    toast.success(`Added to queue: ${a.title}`);
+  };
+
+  const startRadio = async () => {
+    const a = await resolve();
+    if (!a) return;
+    const items = withCover(a);
+    const seed = items[0];
+    if (!seed) return;
+    try {
+      const radio = await fetchRadio(seed.id);
+      usePlaybackStore
+        .getState()
+        .playShelfItems([seed, ...radio.filter((t) => t.id !== seed.id)], 0);
+    } catch {
+      void play(false);
+    }
+  };
+
+  const goToArtist = async () => {
+    const a = await resolve();
+    if (!a) return;
+    const artist = a.artists.find((x) => x.id);
+    if (!artist?.id) {
+      toast.error("No artist page for this album");
+      return;
+    }
+    navigate({ to: "/artist/$id", params: { id: artist.id } });
+  };
+
+  return { play, playNext, addToQueue, startRadio, goToArtist };
+}
+
+export function AlbumMenuItems({
+  controller,
+  primitives,
+}: {
+  controller: ReturnType<typeof useAlbumMenuController>;
+  primitives: typeof ctxPrimitives;
+}) {
+  const { Item, Separator } = primitives;
+  const { play, playNext, addToQueue, startRadio, goToArtist } = controller;
+
+  return (
+    <>
+      <Item onSelect={() => void play(false)}>
+        <PlayIcon />
+        Play
+      </Item>
+      <Item onSelect={() => void play(true)}>
+        <ShuffleIcon />
+        Shuffle play
+      </Item>
+      <Item onSelect={() => void playNext()}>
+        <ListPlusIcon />
+        Play next
+      </Item>
+      <Item onSelect={() => void addToQueue()}>
+        <ListEndIcon />
+        Add to queue
+      </Item>
+      <Item onSelect={() => void startRadio()}>
+        <RadioIcon />
+        Start radio
+      </Item>
+
+      <Separator />
+
+      <Item onSelect={() => void goToArtist()}>
+        <UserIcon />
+        Go to artist
+      </Item>
+    </>
+  );
+}
+
+/** Right-click menu for an album card. */
+export function AlbumContextMenu({
+  albumId,
+  children,
+}: {
+  albumId: string;
+  children: ReactNode;
+}) {
+  const controller = useAlbumMenuController(albumId);
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
+      <ContextMenuContent className="w-56">
+        <AlbumMenuItems controller={controller} primitives={ctxPrimitives} />
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+/** ⋯ button for the album page header. Same actions as the card menu. */
+export function AlbumMoreMenu({ album }: { album: AlbumPage }) {
+  const controller = useAlbumMenuController(album.id, album);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon" aria-label="More actions">
+          <MoreHorizontalIcon />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-56">
+        <AlbumMenuItems controller={controller} primitives={dropPrimitives} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/shared/shelf-card.tsx
+++ b/src/components/shared/shelf-card.tsx
@@ -42,6 +42,7 @@ import { cn } from "@/lib/utils";
 import { ArtworkOutline } from "@/components/shared/artwork-outline";
 import { Thumbnail } from "@/components/shared/thumbnail";
 import { TrackContextMenu } from "@/components/shared/track-context-menu";
+import { AlbumContextMenu } from "@/components/shared/album-menu";
 import { usePlaybackStore } from "@/lib/store/playback";
 import {
   useIsHidden,
@@ -279,13 +280,15 @@ export function ShelfCard({ item, className }: Props) {
 
   if (item.kind === "album") {
     return (
-      <Link
-        to="/album/$id"
-        params={{ id: item.id }}
-        className={cn(CARD_CLASS, className)}
-      >
-        {body}
-      </Link>
+      <AlbumContextMenu albumId={item.id}>
+        <Link
+          to="/album/$id"
+          params={{ id: item.id }}
+          className={cn(CARD_CLASS, className)}
+        >
+          {body}
+        </Link>
+      </AlbumContextMenu>
     );
   }
 

--- a/src/lib/store/playback.test.ts
+++ b/src/lib/store/playback.test.ts
@@ -143,3 +143,26 @@ describe("queueContinuation lifecycle", () => {
     expect(usePlaybackStore.getState().queueContinuation).toBeUndefined();
   });
 });
+
+// The album menu's "Play next" queues a whole album by calling
+// enqueueNext once per track in reverse — each insert lands directly
+// after the current track, so reversing is what restores album order.
+// If enqueueNext's insertion point ever changes, this breaks loudly
+// instead of silently shuffling every album.
+describe("album 'Play next' ordering", () => {
+  beforeEach(() => setup({}));
+
+  it("keeps album order when enqueued back-to-front", () => {
+    setup({ queue: [track("cur"), track("later")], index: 0 });
+    for (const t of [track("a1"), track("a2"), track("a3")].reverse()) {
+      usePlaybackStore.getState().enqueueNext(t);
+    }
+    expect(usePlaybackStore.getState().queue.map((t) => t.videoId)).toEqual([
+      "cur",
+      "a1",
+      "a2",
+      "a3",
+      "later",
+    ]);
+  });
+});

--- a/src/routes/album.$id.tsx
+++ b/src/routes/album.$id.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { AlertCircleIcon } from "lucide-react";
 import { fetchAlbum } from "@/lib/innertube/album";
 import { EntityHeader } from "@/components/shared/entity-header";
+import { AlbumMoreMenu } from "@/components/shared/album-menu";
 import { TrackList } from "@/components/shared/track-list";
 import { JumpToCurrentButton } from "@/components/shared/jump-to-current-button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -92,6 +93,7 @@ function AlbumPageView() {
             usePlaybackStore.getState().setShuffle(true);
           }
         }}
+        actions={<AlbumMoreMenu album={data} />}
       />
       {subtitleParts.length > 0 ? (
         <p className="-mt-4 flex flex-wrap items-center gap-1 text-sm text-muted-foreground">


### PR DESCRIPTION
Right-clicking an album does nothing today. Songs open a full context menu and playlists offer pin/hide, but albums are a bare link, so the only way to hear one is to click it and let it replace whatever is already queued. There is no way to line an album up behind the current track, and the album page has no menu button either.

**What changed.**

- Albums now answer a right-click anywhere they appear (home, search, artist, library) with Play, Shuffle play, Play next, Add to queue, Start radio and Go to artist.
- The album page gets a matching more-actions button beside Play and Shuffle, so the same actions are reachable without hunting for a card.
- Both surfaces share one controller and one item list, following the split `track-context-menu` already uses, so the right-click menu and the button menu cannot drift apart.
- A card only carries the album browse id, so actions resolve the track list on demand through the same `["album", id]` query key the album page uses: right-clicking a card warms that page, and opening the page first makes the menu instant.
- "Play next" walks the album backwards, because `enqueueNext` always inserts directly after the current track. That is load bearing and easy to break by accident, so it has a test.