### PR TITLE
feat(player): share one lyrics panel across player layouts

### DIFF
--- a/src/components/layout/player-bar-bottom.tsx
+++ b/src/components/layout/player-bar-bottom.tsx
@@ -28,10 +28,10 @@ import { LikeDislikeButtons } from "@/components/shared/like-buttons";
 import { ArtistLinks } from "@/components/shared/artist-links";
 import { QueuePopover } from "@/components/layout/queue-panel";
 import {
-  LyricsBody,
   LyricsSourceButton,
   useLyricsView,
 } from "@/components/layout/lyrics-view";
+import { PlayerMediaPanel } from "@/components/layout/player-media-panel";
 import {
   ProgressSlider,
   VolumeControl,
@@ -296,15 +296,13 @@ function LyricsPopover({
         align="end"
         side="top"
         sideOffset={12}
-        className="flex h-[28rem] w-[24rem] flex-col gap-2 p-0"
+        className="flex h-[28rem] w-[24rem] flex-col p-0"
       >
-        <header className="flex shrink-0 items-center justify-between border-b border-hairline px-3 py-2">
-          <span className="text-sm font-medium">Lyrics</span>
-          <LyricsSourceButton state={state} />
-        </header>
-        <div className="min-h-0 flex-1 overflow-hidden px-2 pb-3">
-          <LyricsBody state={state} />
-        </div>
+        <PlayerMediaPanel
+          lyricsState={state}
+          trailing={<LyricsSourceButton state={state} />}
+          headerClassName="border-b border-hairline px-2 py-1"
+        />
       </PopoverContent>
     </Popover>
   );

--- a/src/components/layout/player-bar.tsx
+++ b/src/components/layout/player-bar.tsx
@@ -16,10 +16,10 @@ import {
 } from "lucide-react";
 import { QueueBody, QueueToggleButton } from "@/components/layout/queue-panel";
 import {
-  LyricsBody,
   LyricsSourceButton,
   useLyricsView,
 } from "@/components/layout/lyrics-view";
+import { PlayerMediaPanel } from "@/components/layout/player-media-panel";
 import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { toast } from "sonner";
@@ -686,11 +686,11 @@ export function PlayerBar({
         </div>
       </div>
 
-            {/* Lyrics flow — fills the rest of the cover-branch flex
+            {/* Lyrics — fills the rest of the cover-branch flex
                 column. Lives inside the same motion.div as the cover
                 so the whole non-queue body crossfades as one unit. */}
             <div className="flex min-h-0 flex-1 flex-col px-3">
-              <LyricsBody state={lyricsState} />
+              <PlayerMediaPanel lyricsState={lyricsState} />
             </div>
           </motion.div>
         )}

--- a/src/components/layout/player-media-panel.tsx
+++ b/src/components/layout/player-media-panel.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import {
+  LyricsBody,
+  type LyricsViewState,
+} from "@/components/layout/lyrics-view";
+import { cn } from "@/lib/utils";
+
+/**
+ * The flowing lyrics area under the player cover, and inside the
+ * bottom-bar popover. One component so both layouts stay in sync.
+ */
+export function PlayerMediaPanel({
+  lyricsState,
+  trailing,
+  headerClassName,
+}: {
+  lyricsState: LyricsViewState;
+  /** Extra header control — the lyrics-source picker on the bottom-bar popover. */
+  trailing?: ReactNode;
+  headerClassName?: string;
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      {trailing != null ? (
+        <div
+          className={cn(
+            "flex shrink-0 items-center justify-between gap-2",
+            headerClassName,
+          )}
+        >
+          <span className="px-1 text-sm font-medium">Lyrics</span>
+          {trailing}
+        </div>
+      ) : null}
+      <div className="min-h-0 flex-1">
+        <LyricsBody state={lyricsState} />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract `PlayerMediaPanel` so the side player and the bottom-bar lyrics popover render the same lyrics surface.
- The popover keeps its source-picker header; the side player stays headerless until a later chapters change needs tabs.

## Why
Both layouts were independently wiring `LyricsBody` + a one-off header. A shared panel keeps them in sync and is the hook the chapters PR hangs tabs on.

## Scope
Frontend-only, rebased cleanly on `v0.4.4` / current `origin/main`. No playback, auth, or stream-resolve commits.

## Test plan
- [x] `pnpm test`
- [x] `tsc --noEmit`
- [ ] Side player: lyrics still flow under the cover, source picker still in the bottom row
- [ ] Bottom-bar lyrics popover: title + source picker + lyrics body
- [ ] No track: lyrics button stays disabled

## Notes
Independent of the macOS / WEB_REMIX / speed PRs. The follow-up chapters PR (`feature/chapters`) stacks on this commit.
