### PR TITLE
feat(player): show YouTube chapters next to lyrics

### DIFF
--- a/src/components/layout/chapters-view.tsx
+++ b/src/components/layout/chapters-view.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { formatTimestamp } from "@/lib/format";
+import {
+  fetchVideoChapters,
+  type VideoChapter,
+} from "@/lib/innertube/chapters";
+import { usePlaybackStore } from "@/lib/store/playback";
+import { useScrubStore } from "@/lib/store/scrub";
+import { cn } from "@/lib/utils";
+
+const ONE_HOUR = 60 * 60 * 1000;
+
+export function useVideoChapters(videoId: string | undefined) {
+  return useQuery({
+    queryKey: ["chapters", "v1", videoId],
+    queryFn: ({ signal }) => fetchVideoChapters(videoId, signal),
+    enabled: !!videoId,
+    staleTime: ONE_HOUR,
+    retry: 1,
+  });
+}
+
+function activeChapterIdx(chapters: VideoChapter[], position: number): number {
+  let active = 0;
+  for (let i = 0; i < chapters.length; i++) {
+    if (chapters[i].start <= position) active = i;
+    else break;
+  }
+  return active;
+}
+
+export function ChaptersBody({ chapters }: { chapters: VideoChapter[] }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const playbackPosition = usePlaybackStore((s) => s.position);
+  const seek = usePlaybackStore((s) => s.seek);
+  const scrub = useScrubStore((s) => s.scrub);
+  const position = scrub ?? playbackPosition;
+  const activeIdx = activeChapterIdx(chapters, position);
+
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const el = container.querySelector<HTMLElement>(
+      `[data-chapter-idx="${activeIdx}"]`,
+    );
+    el?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [activeIdx, chapters]);
+
+  return (
+    <div
+      ref={scrollRef}
+      className="lyrics-no-scrollbar lyrics-mask-bottom flex h-full flex-col gap-0.5 overflow-y-auto px-1 pb-12"
+    >
+      {chapters.map((ch, i) => {
+        const active = i === activeIdx;
+        return (
+          <button
+            key={`${ch.start}-${i}`}
+            type="button"
+            data-chapter-idx={i}
+            onClick={() => seek(ch.start)}
+            aria-current={active ? "true" : undefined}
+            className={cn(
+              "grid grid-cols-[auto_1fr] items-baseline gap-2 rounded-md px-2 py-1.5 text-left transition-colors",
+              "hover:bg-black/30",
+              active
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground",
+            )}
+          >
+            <span
+              className={cn(
+                "text-xs tabular-nums",
+                active ? "text-brand" : "text-muted-foreground",
+              )}
+            >
+              {formatTimestamp(ch.start)}
+            </span>
+            <span
+              className={cn(
+                "min-w-0 text-sm leading-snug",
+                active ? "font-medium text-foreground" : "text-foreground/80",
+              )}
+            >
+              {ch.title}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/layout/player-bar-bottom.tsx
+++ b/src/components/layout/player-bar-bottom.tsx
@@ -233,7 +233,7 @@ export function PlayerBarBottom() {
         {/* RIGHT wing: secondary actions, justified to the right edge. */}
         <div className="flex flex-1 items-center justify-end gap-0.5">
           {track ? <LikeDislikeButtons videoId={track.videoId} track={track} /> : null}
-          <LyricsPopover state={lyricsState} />
+          <LyricsPopover state={lyricsState} videoId={track?.videoId} />
           <QueuePopover />
           <VolumeControl direction="vertical" />
           <PlayerMoreMenu track={track} />
@@ -270,8 +270,10 @@ export function PlayerBarBottom() {
 
 function LyricsPopover({
   state,
+  videoId,
 }: {
   state: ReturnType<typeof useLyricsView>;
+  videoId?: string;
 }) {
   if (!state.hasTrack) {
     return (
@@ -299,6 +301,7 @@ function LyricsPopover({
         className="flex h-[28rem] w-[24rem] flex-col p-0"
       >
         <PlayerMediaPanel
+          videoId={videoId}
           lyricsState={state}
           trailing={<LyricsSourceButton state={state} />}
           headerClassName="border-b border-hairline px-2 py-1"

--- a/src/components/layout/player-bar-bottom.tsx
+++ b/src/components/layout/player-bar-bottom.tsx
@@ -28,10 +28,10 @@ import { LikeDislikeButtons } from "@/components/shared/like-buttons";
 import { ArtistLinks } from "@/components/shared/artist-links";
 import { QueuePopover } from "@/components/layout/queue-panel";
 import {
-  LyricsBody,
   LyricsSourceButton,
   useLyricsView,
 } from "@/components/layout/lyrics-view";
+import { PlayerMediaPanel } from "@/components/layout/player-media-panel";
 import {
   ProgressSlider,
   VolumeControl,
@@ -296,15 +296,13 @@ function LyricsPopover({
         align="end"
         side="top"
         sideOffset={12}
-        className="flex h-[28rem] w-[24rem] flex-col gap-2 p-0"
+        className="flex h-[28rem] w-[24rem] flex-col p-0"
       >
-        <header className="flex shrink-0 items-center justify-between border-b border-hairline px-3 py-2">
-          <span className="text-sm font-medium">Lyrics</span>
-          <LyricsSourceButton state={state} />
-        </header>
-        <div className="min-h-0 flex-1 overflow-hidden px-2 pb-3">
-          <LyricsBody state={state} />
-        </div>
+        <PlayerMediaPanel
+          lyricsState={state}
+          trailing={<LyricsSourceButton state={state} />}
+          headerClassName="border-b border-hairline px-2 py-1"
+        />
       </PopoverContent>
     </Popover>
   );

--- a/src/components/layout/player-bar.tsx
+++ b/src/components/layout/player-bar.tsx
@@ -16,10 +16,10 @@ import {
 } from "lucide-react";
 import { QueueBody, QueueToggleButton } from "@/components/layout/queue-panel";
 import {
-  LyricsBody,
   LyricsSourceButton,
   useLyricsView,
 } from "@/components/layout/lyrics-view";
+import { PlayerMediaPanel } from "@/components/layout/player-media-panel";
 import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { toast } from "sonner";
@@ -682,11 +682,11 @@ export function PlayerBar({
         </div>
       </div>
 
-            {/* Lyrics flow — fills the rest of the cover-branch flex
+            {/* Lyrics — fills the rest of the cover-branch flex
                 column. Lives inside the same motion.div as the cover
                 so the whole non-queue body crossfades as one unit. */}
             <div className="flex min-h-0 flex-1 flex-col px-3">
-              <LyricsBody state={lyricsState} />
+              <PlayerMediaPanel lyricsState={lyricsState} />
             </div>
           </motion.div>
         )}

--- a/src/components/layout/player-bar.tsx
+++ b/src/components/layout/player-bar.tsx
@@ -20,6 +20,7 @@ import {
   useLyricsView,
 } from "@/components/layout/lyrics-view";
 import { PlayerMediaPanel } from "@/components/layout/player-media-panel";
+import { formatTimestamp } from "@/lib/format";
 import { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { toast } from "sonner";
@@ -83,10 +84,7 @@ export function useITunesCover(track: QueueTrack | undefined): string | null {
 }
 
 export function formatTime(seconds: number): string {
-  if (!Number.isFinite(seconds) || seconds < 0) return "0:00";
-  const m = Math.floor(seconds / 60);
-  const s = Math.floor(seconds % 60);
-  return `${m}:${s.toString().padStart(2, "0")}`;
+  return formatTimestamp(seconds);
 }
 
 /**
@@ -682,11 +680,15 @@ export function PlayerBar({
         </div>
       </div>
 
-            {/* Lyrics — fills the rest of the cover-branch flex
-                column. Lives inside the same motion.div as the cover
-                so the whole non-queue body crossfades as one unit. */}
+            {/* Lyrics / chapters — fills the rest of the cover-branch
+                flex column. Lives inside the same motion.div as the
+                cover so the whole non-queue body crossfades as one. */}
             <div className="flex min-h-0 flex-1 flex-col px-3">
-              <PlayerMediaPanel lyricsState={lyricsState} />
+              <PlayerMediaPanel
+                videoId={track?.videoId}
+                lyricsState={lyricsState}
+                headerClassName="mb-1 border-b border-hairline"
+              />
             </div>
           </motion.div>
         )}

--- a/src/components/layout/player-media-panel.tsx
+++ b/src/components/layout/player-media-panel.tsx
@@ -1,39 +1,88 @@
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import {
   LyricsBody,
   type LyricsViewState,
 } from "@/components/layout/lyrics-view";
+import {
+  ChaptersBody,
+  useVideoChapters,
+} from "@/components/layout/chapters-view";
+import { AnimatedTabs } from "@/components/ui/animated-tabs";
 import { cn } from "@/lib/utils";
 
+type Tab = "lyrics" | "chapters";
+
 /**
- * The flowing lyrics area under the player cover, and inside the
- * bottom-bar popover. One component so both layouts stay in sync.
+ * The flowing area under the player cover: lyrics, or lyrics/chapters
+ * tabs when the current video has linked YouTube chapters (OST dumps,
+ * long mixes, uploaded concerts).
  */
 export function PlayerMediaPanel({
+  videoId,
   lyricsState,
   trailing,
   headerClassName,
 }: {
+  videoId: string | undefined;
   lyricsState: LyricsViewState;
   /** Extra header control — the lyrics-source picker on the bottom-bar popover. */
   trailing?: ReactNode;
   headerClassName?: string;
 }) {
+  const chaptersQuery = useVideoChapters(videoId);
+  const chapters = chaptersQuery.data ?? null;
+  const hasChapters = !!chapters && chapters.length >= 2;
+
+  const [tab, setTab] = useState<Tab>("lyrics");
+  const [chosen, setChosen] = useState(false);
+
+  useEffect(() => {
+    setTab("lyrics");
+    setChosen(false);
+  }, [videoId]);
+
+  useEffect(() => {
+    if (!chosen && hasChapters) setTab("chapters");
+  }, [hasChapters, chosen]);
+
+  const showHeader = hasChapters || trailing != null;
+  const active: Tab = hasChapters ? tab : "lyrics";
+
   return (
     <div className="flex h-full min-h-0 flex-1 flex-col">
-      {trailing != null ? (
+      {showHeader ? (
         <div
           className={cn(
             "flex shrink-0 items-center justify-between gap-2",
             headerClassName,
           )}
         >
-          <span className="px-1 text-sm font-medium">Lyrics</span>
+          {hasChapters ? (
+            <AnimatedTabs
+              activeTab={active}
+              onChange={(id) => {
+                setChosen(true);
+                setTab(id as Tab);
+              }}
+              variant="underline"
+              className="border-b-0 [&_button]:px-3 [&_button]:py-1.5 [&_button]:text-sm"
+              tabs={[
+                { id: "lyrics", label: "Lyrics" },
+                { id: "chapters", label: "Chapters" },
+              ]}
+            />
+          ) : trailing ? (
+            <span className="px-1 text-sm font-medium">Lyrics</span>
+          ) : null}
           {trailing}
         </div>
       ) : null}
       <div className="min-h-0 flex-1">
-        <LyricsBody state={lyricsState} />
+        {active === "chapters" && chapters ? (
+          <ChaptersBody chapters={chapters} />
+        ) : (
+          <LyricsBody state={lyricsState} />
+        )}
       </div>
     </div>
   );

--- a/src/components/layout/player-media-panel.tsx
+++ b/src/components/layout/player-media-panel.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import {
+  LyricsBody,
+  type LyricsViewState,
+} from "@/components/layout/lyrics-view";
+import { cn } from "@/lib/utils";
+
+/**
+ * The flowing lyrics area under the player cover, and inside the
+ * bottom-bar popover. One component so both layouts stay in sync.
+ */
+export function PlayerMediaPanel({
+  lyricsState,
+  trailing,
+  headerClassName,
+}: {
+  lyricsState: LyricsViewState;
+  /** Extra header control — the lyrics-source picker on the bottom-bar popover. */
+  trailing?: ReactNode;
+  headerClassName?: string;
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-1 flex-col">
+      {trailing != null ? (
+        <div
+          className={cn(
+            "flex shrink-0 items-center justify-between gap-2",
+            headerClassName,
+          )}
+        >
+          <span className="px-1 text-sm font-medium">Lyrics</span>
+          {trailing}
+        </div>
+      ) : null}
+      <div className="min-h-0 flex-1">
+        <LyricsBody state={lyricsState} />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatTimestamp } from "./format";
+
+describe("formatTimestamp", () => {
+  it("formats under an hour as m:ss", () => {
+    expect(formatTimestamp(0)).toBe("0:00");
+    expect(formatTimestamp(124)).toBe("2:04");
+    expect(formatTimestamp(3599)).toBe("59:59");
+  });
+
+  it("formats an hour or more as h:mm:ss", () => {
+    expect(formatTimestamp(3600)).toBe("1:00:00");
+    expect(formatTimestamp(5489)).toBe("1:31:29");
+  });
+
+  it("guards non-finite input", () => {
+    expect(formatTimestamp(Number.NaN)).toBe("0:00");
+    expect(formatTimestamp(-3)).toBe("0:00");
+  });
+});

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -28,3 +28,15 @@ export function formatDateTime(unixMs: number): string {
     timeStyle: "short",
   });
 }
+
+/** "1:02:45" / "3:09" media timestamp from a duration in seconds. */
+export function formatTimestamp(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return "0:00";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  if (h > 0) {
+    return `${h}:${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+  }
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}

--- a/src/lib/innertube/chapters.test.ts
+++ b/src/lib/innertube/chapters.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  chaptersFromPlayer,
+  cleanChapterTitle,
+  parseClock,
+  parseDescriptionChapters,
+  parseLinkedDescriptionChapters,
+  parseOfficialChapters,
+} from "./chapters";
+
+vi.mock("@tauri-apps/plugin-http", () => ({ fetch: vi.fn() }));
+
+/**
+ * Snippet of the live shortDescription for
+ * https://www.youtube.com/watch?v=7E15LSbKm_Q
+ * (Divinity: Original Sin OST). Zero-width spaces after each timestamp
+ * are how YouTube marks the linked chapter anchors.
+ */
+const OST_DESCRIPTION = [
+  "Composed by Kirill Pokrovsky. RIP (1962 – 2015)",
+  "If you know the name of a missing track, please write in the comments.",
+  "Album links added.",
+  "",
+  "0:00\u200b       -   Track 1 - Dance Of Death - http://bit.ly/1AvOjmP\u200b",
+  "2:04\u200b       -   Track 2 - Drunk with Dwarven Mirth - http://bit.ly/1r0bcb7\u200b",
+  "3:49\u200b       -   Track 3 - Anirban Encounter 3",
+  "11:19\u200b      -   Track 7",
+  "41:35\u200b      -   Track 16 -",
+  "01:01:30\u200b   -   Track 23 -",
+  "01:43:47\u200b   -   Track 38    Combat",
+].join("\n");
+
+describe("parseClock", () => {
+  it("reads m:ss and h:mm:ss", () => {
+    expect(parseClock("0:00")).toBe(0);
+    expect(parseClock("2:04")).toBe(124);
+    expect(parseClock("01:01:30")).toBe(3690);
+  });
+
+  it("rejects impossible minutes", () => {
+    expect(parseClock("1:80")).toBeUndefined();
+  });
+});
+
+describe("cleanChapterTitle", () => {
+  it("strips the gutter dash, trailing URL, and empty dash", () => {
+    expect(
+      cleanChapterTitle("       -   Track 1 - Dance Of Death - http://bit.ly/1AvOjmP"),
+    ).toBe("Track 1 - Dance Of Death");
+    expect(cleanChapterTitle("   -   Track 16 -")).toBe("Track 16");
+    expect(cleanChapterTitle("   -   Track 38    Combat")).toBe("Track 38 Combat");
+  });
+});
+
+describe("parseDescriptionChapters", () => {
+  it("parses a real OST description into titled chapters", () => {
+    const chapters = parseDescriptionChapters(OST_DESCRIPTION);
+    expect(chapters[0]).toEqual({
+      start: 0,
+      title: "Track 1 - Dance Of Death",
+    });
+    expect(chapters[1]).toEqual({
+      start: 124,
+      title: "Track 2 - Drunk with Dwarven Mirth",
+    });
+    expect(chapters.find((c) => c.start === 3690)?.title).toBe("Track 23");
+    expect(chapters.find((c) => c.start === 6227)?.title).toBe("Track 38 Combat");
+    expect(chapters).toHaveLength(7);
+  });
+
+  it("ignores a description with no timestamp list", () => {
+    expect(parseDescriptionChapters("Just a song. No chapters here.")).toEqual(
+      [],
+    );
+  });
+
+  it("ignores stray times that do not open at 0:00", () => {
+    expect(
+      parseDescriptionChapters("Call us at 3:00 PM\nShow ends 4:15"),
+    ).toEqual([]);
+  });
+
+  it("accepts bracketed timestamps", () => {
+    const chapters = parseDescriptionChapters(
+      "[0:00] Intro\n[1:30] Verse",
+    );
+    expect(chapters).toEqual([
+      { start: 0, title: "Intro" },
+      { start: 90, title: "Verse" },
+    ]);
+  });
+});
+
+describe("parseOfficialChapters", () => {
+  it("reads chapterRenderer markers", () => {
+    const root = {
+      playerOverlays: {
+        markersMap: [
+          {
+            key: "DESCRIPTION_CHAPTERS",
+            value: {
+              chapters: [
+                {
+                  chapterRenderer: {
+                    title: { simpleText: "Intro" },
+                    timeRangeStartMillis: 0,
+                  },
+                },
+                {
+                  chapterRenderer: {
+                    title: { simpleText: "Drop" },
+                    timeRangeStartMillis: "45000",
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    expect(parseOfficialChapters(root)).toEqual([
+      { start: 0, title: "Intro" },
+      { start: 45, title: "Drop" },
+    ]);
+  });
+
+  it("reads macroMarkersListItemRenderer rows", () => {
+    const root = {
+      engagementPanels: [
+        {
+          macroMarkersListItemRenderer: {
+            title: { simpleText: "Cold open" },
+            onTap: { watchEndpoint: { startTimeSeconds: 0 } },
+          },
+        },
+        {
+          macroMarkersListItemRenderer: {
+            title: { runs: [{ text: "Theme" }] },
+            onTap: { watchEndpoint: { startTimeSeconds: 12 } },
+          },
+        },
+      ],
+    };
+    expect(parseOfficialChapters(root)).toEqual([
+      { start: 0, title: "Cold open" },
+      { start: 12, title: "Theme" },
+    ]);
+  });
+});
+
+describe("parseLinkedDescriptionChapters", () => {
+  it("uses commandRuns startTimeSeconds and the rest of the line as the title", () => {
+    const content = [
+      "Notes",
+      "",
+      "0:00       -   Track 1 - Dance Of Death - http://bit.ly/1AvOjmP",
+      "2:04       -   Track 2 - Drunk with Dwarven Mirth",
+    ].join("\n");
+    const t1 = content.indexOf("0:00");
+    const t2 = content.indexOf("2:04");
+    const root = {
+      attributedDescriptionBodyText: {
+        content,
+        commandRuns: [
+          {
+            startIndex: t1,
+            length: 4,
+            onTap: {
+              innertubeCommand: {
+                watchEndpoint: { videoId: "abc", startTimeSeconds: 0 },
+              },
+            },
+          },
+          {
+            startIndex: t2,
+            length: 4,
+            onTap: {
+              innertubeCommand: {
+                watchEndpoint: { videoId: "abc", startTimeSeconds: 124 },
+              },
+            },
+          },
+        ],
+      },
+    };
+    expect(parseLinkedDescriptionChapters(root)).toEqual([
+      { start: 0, title: "Track 1 - Dance Of Death" },
+      { start: 124, title: "Track 2 - Drunk with Dwarven Mirth" },
+    ]);
+  });
+});
+
+describe("chaptersFromPlayer", () => {
+  it("prefers official markers over the description", () => {
+    const root = {
+      videoDetails: { shortDescription: OST_DESCRIPTION },
+      chapterRenderer: {
+        title: { simpleText: "Official A" },
+        timeRangeStartMillis: 0,
+      },
+      extra: {
+        chapterRenderer: {
+          title: { simpleText: "Official B" },
+          timeRangeStartMillis: 10_000,
+        },
+      },
+    };
+    expect(chaptersFromPlayer(root)).toEqual([
+      { start: 0, title: "Official A" },
+      { start: 10, title: "Official B" },
+    ]);
+  });
+
+  it("falls back to the description when no markers ship", () => {
+    const chapters = chaptersFromPlayer({
+      videoDetails: { shortDescription: OST_DESCRIPTION },
+    });
+    expect(chapters?.[0].title).toBe("Track 1 - Dance Of Death");
+    expect(chapters?.length).toBe(7);
+  });
+
+  it("returns null when the video has no chapter list", () => {
+    expect(
+      chaptersFromPlayer({
+        videoDetails: { shortDescription: "A regular song." },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("fetchVideoChapters", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("posts WEB /player and returns parsed chapters", async () => {
+    const http = await import("@tauri-apps/plugin-http");
+    vi.mocked(http.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          videoDetails: { shortDescription: OST_DESCRIPTION },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const { fetchVideoChapters } = await import("./chapters");
+    const chapters = await fetchVideoChapters("7E15LSbKm_Q");
+    expect(chapters?.[0]).toMatchObject({
+      start: 0,
+      title: "Track 1 - Dance Of Death",
+    });
+    const [url, init] = vi.mocked(http.fetch).mock.calls[0] ?? [];
+    expect(String(url)).toContain("www.youtube.com/youtubei/v1/player");
+    expect(JSON.parse(String((init as { body?: string }).body)).videoId).toBe(
+      "7E15LSbKm_Q",
+    );
+  });
+
+  it("throws on a non-OK player response so the query can retry", async () => {
+    const http = await import("@tauri-apps/plugin-http");
+    vi.mocked(http.fetch).mockResolvedValue(new Response("nope", { status: 500 }));
+    const { fetchVideoChapters } = await import("./chapters");
+    await expect(fetchVideoChapters("7E15LSbKm_Q")).rejects.toThrow(
+      /player 500/,
+    );
+  });
+});

--- a/src/lib/innertube/chapters.ts
+++ b/src/lib/innertube/chapters.ts
@@ -1,0 +1,303 @@
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { readRuns, type YtNode } from "./shared";
+
+/**
+ * Timestamped chapters on a YouTube video — the clickable markers the
+ * official player draws on the progress bar, and the "0:00 Track name"
+ * links in the description that produce them.
+ *
+ * YT Music's WEB_REMIX `/next` and `/player` do not carry this data
+ * (verified against a 152-chapter OST). The regular YouTube WEB `/player`
+ * does: `videoDetails.shortDescription` has the timestamp list, and some
+ * videos also ship a structured `chapterRenderer` / `markersMap`.
+ *
+ * Anonymous on purpose, same rationale as YTM lyrics: it works signed
+ * out, and pairing the user's Google cookies with a www.youtube.com WEB
+ * client is a mismatch we don't need for a read-only metadata panel.
+ */
+
+export type VideoChapter = {
+  start: number;
+  title: string;
+};
+
+const YT_API = "https://www.youtube.com/youtubei/v1";
+
+const WEB_CLIENT = {
+  clientName: "WEB",
+  clientVersion: "2.20240815.01.00",
+  hl: "en",
+  gl: "US",
+};
+
+const HEADERS: Record<string, string> = {
+  "Content-Type": "application/json",
+  "X-YouTube-Client-Name": "1",
+  "X-YouTube-Client-Version": WEB_CLIENT.clientVersion,
+  Origin: "https://www.youtube.com",
+  Referer: "https://www.youtube.com/",
+  "User-Agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+};
+
+/** Zero-width space / BOM YouTube inserts around linked timestamps. */
+const INVISIBLE = /\u200b|\ufeff/g;
+
+export async function fetchVideoChapters(
+  videoId: string | undefined,
+  signal?: AbortSignal,
+): Promise<VideoChapter[] | null> {
+  if (!videoId) return null;
+
+  const res = await tauriFetch(`${YT_API}/player?prettyPrint=false`, {
+    method: "POST",
+    headers: HEADERS,
+    body: JSON.stringify({
+      context: { client: WEB_CLIENT },
+      videoId,
+      contentCheckOk: true,
+      racyCheckOk: true,
+    }),
+    signal,
+  });
+  if (!res.ok) {
+    throw new Error(`YouTube player ${res.status}`);
+  }
+  const json = (await res.json()) as YtNode;
+  return chaptersFromPlayer(json);
+}
+
+/**
+ * Pull chapters out of a WEB `/player` (or `/next`) payload. Official
+ * markers win when present — their titles are already cleaned. Otherwise
+ * we parse the description's timestamp list, which is what YouTube itself
+ * turns into linked chapters.
+ */
+export function chaptersFromPlayer(root: YtNode): VideoChapter[] | null {
+  const official = parseOfficialChapters(root);
+  if (official && official.length >= 2) return official;
+
+  const desc = root?.videoDetails?.shortDescription;
+  if (typeof desc === "string") {
+    const parsed = parseDescriptionChapters(desc);
+    if (parsed.length >= 2) return parsed;
+  }
+
+  const linked = parseLinkedDescriptionChapters(root);
+  if (linked && linked.length >= 2) return linked;
+
+  return null;
+}
+
+/**
+ * Structured chapter renderers. Walks the tree rather than a hardcoded
+ * path: WEB `/player` puts them under `markersMap`, WEB `/next` under an
+ * engagement panel, and either wrapper has been renamed before.
+ */
+export function parseOfficialChapters(root: unknown): VideoChapter[] | null {
+  const fromRenderer: VideoChapter[] = [];
+  const fromMarkers: VideoChapter[] = [];
+  walk(root, (node) => {
+    if (node.chapterRenderer && typeof node.chapterRenderer === "object") {
+      const ch = chapterFromRenderer(node.chapterRenderer as YtNode);
+      if (ch) fromRenderer.push(ch);
+      return;
+    }
+    if (
+      node.macroMarkersListItemRenderer &&
+      typeof node.macroMarkersListItemRenderer === "object"
+    ) {
+      const ch = chapterFromMacro(node.macroMarkersListItemRenderer as YtNode);
+      if (ch) fromRenderer.push(ch);
+      return;
+    }
+    if (node.key === "DESCRIPTION_CHAPTERS" && node.value) {
+      const chapters = (node.value as YtNode).chapters;
+      if (Array.isArray(chapters)) {
+        for (const entry of chapters) {
+          const raw = (entry as YtNode)?.chapterRenderer as YtNode | undefined;
+          const ch = raw ? chapterFromRenderer(raw) : null;
+          if (ch) fromMarkers.push(ch);
+        }
+      }
+    }
+  });
+  const list = fromMarkers.length >= 2 ? fromMarkers : fromRenderer;
+  return finalize(list);
+}
+
+/**
+ * Description timestamps of the form YouTube promotes to chapters:
+ *
+ *   0:00  Track 1 - Dance Of Death
+ *   2:04  Track 2 - Drunk with Dwarven Mirth
+ *   01:01:30  Track 23
+ *
+ * Requires a 0:00 opener and at least two hits, matching YouTube's own
+ * rule for turning a timestamp list into linked chapters. Stray times
+ * in prose ("call 3:00 PM") therefore don't become a one-item "chapter".
+ */
+export function parseDescriptionChapters(description: string): VideoChapter[] {
+  const lines = description.replace(/\r\n/g, "\n").split("\n");
+  const out: VideoChapter[] = [];
+  for (const raw of lines) {
+    const line = raw.replace(INVISIBLE, "").trim();
+    const parsed = parseTimestampLine(line);
+    if (parsed) out.push(parsed);
+  }
+  return finalize(out) ?? [];
+}
+
+/**
+ * Linked timestamps in a WEB `/next` attributed description. Each
+ * `commandRun` with a `watchEndpoint.startTimeSeconds` is one chapter
+ * YouTube already decided to make clickable — more precise than a regex
+ * when we happen to have the next payload.
+ */
+export function parseLinkedDescriptionChapters(
+  root: unknown,
+): VideoChapter[] | null {
+  const out: VideoChapter[] = [];
+  walk(root, (node) => {
+    const content = node.content;
+    const runs = node.commandRuns;
+    if (typeof content !== "string" || !Array.isArray(runs)) return;
+    for (const run of runs) {
+      const r = run as YtNode;
+      const start = startTimeSeconds(r);
+      if (start === undefined) continue;
+      const idx = typeof r.startIndex === "number" ? r.startIndex : 0;
+      const len = typeof r.length === "number" ? r.length : 0;
+      const after = idx + len;
+      const nl = content.indexOf("\n", after);
+      const rest = content.slice(after, nl === -1 ? undefined : nl);
+      out.push({
+        start,
+        title: cleanChapterTitle(rest.replace(INVISIBLE, "")),
+      });
+    }
+  });
+  return finalize(out);
+}
+
+function parseTimestampLine(line: string): VideoChapter | null {
+  // Optional wrapping brackets: "[0:00] Intro" / "(0:00) Intro".
+  const m = line.match(/^[[(]?((?:\d{1,2}:)?\d{1,2}:\d{2})[\])]?(?!\d)(.*)$/);
+  if (!m) return null;
+  const start = parseClock(m[1]);
+  if (start === undefined) return null;
+  return { start, title: cleanChapterTitle(m[2]) };
+}
+
+/** "2:04" / "01:01:30" → seconds. Rejects impossible minutes/seconds. */
+export function parseClock(text: string): number | undefined {
+  const parts = text.split(":").map((p) => parseInt(p, 10));
+  if (parts.some((n) => Number.isNaN(n))) return undefined;
+  let h = 0;
+  let m: number;
+  let s: number;
+  if (parts.length === 2) {
+    [m, s] = parts;
+  } else if (parts.length === 3) {
+    [h, m, s] = parts;
+  } else {
+    return undefined;
+  }
+  if (m > 59 || s > 59) return undefined;
+  return h * 3600 + m * 60 + s;
+}
+
+export function cleanChapterTitle(raw: string): string {
+  let t = raw.replace(INVISIBLE, "").trim();
+  // Leading separators the timestamp list uses as a gutter.
+  t = t.replace(/^[-–—|:·.•]+\s*/, "");
+  // Trailing " - https://…" album links that ride along on OST dumps.
+  t = t.replace(/\s*[-–—]\s*https?:\/\/\S+\s*$/i, "");
+  t = t.replace(/\s*https?:\/\/\S+\s*$/i, "");
+  t = t.replace(/\s*[-–—|:]\s*$/, "");
+  t = t.replace(/\s+/g, " ").trim();
+  return t;
+}
+
+function chapterFromRenderer(raw: YtNode): VideoChapter | null {
+  const title = readRuns(raw.title).trim();
+  const ms = asNumber(raw.timeRangeStartMillis);
+  const start =
+    ms !== undefined
+      ? ms / 1000
+      : (startTimeSeconds(raw) ?? startTimeSeconds(raw.onActiveCommand));
+  if (start === undefined) return null;
+  return { start, title };
+}
+
+function chapterFromMacro(raw: YtNode): VideoChapter | null {
+  const title = readRuns(raw.title).trim();
+  const start =
+    startTimeSeconds(raw) ??
+    startTimeSeconds(raw.onTap) ??
+    startTimeSeconds(raw.onTap?.watchEndpoint);
+  if (start === undefined) return null;
+  return { start, title };
+}
+
+function startTimeSeconds(node: unknown): number | undefined {
+  if (!node || typeof node !== "object") return undefined;
+  const n = node as YtNode;
+  const direct = asNumber(n.startTimeSeconds);
+  if (direct !== undefined) return direct;
+  const we = n.watchEndpoint ?? n.onTap?.watchEndpoint ?? n.onTap?.innertubeCommand?.watchEndpoint;
+  const fromWe = asNumber(we?.startTimeSeconds);
+  if (fromWe !== undefined) return fromWe;
+  if (n.onTap || n.innertubeCommand || n.watchEndpoint) {
+    return (
+      startTimeSeconds(n.onTap) ??
+      startTimeSeconds(n.innertubeCommand) ??
+      startTimeSeconds(n.watchEndpoint)
+    );
+  }
+  return undefined;
+}
+
+function asNumber(v: unknown): number | undefined {
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "string" && v.trim()) {
+    const n = Number(v);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+}
+
+function finalize(list: VideoChapter[]): VideoChapter[] | null {
+  if (list.length < 2) return null;
+  const sorted = [...list].sort((a, b) => a.start - b.start);
+  const deduped: VideoChapter[] = [];
+  for (const ch of sorted) {
+    const prev = deduped[deduped.length - 1];
+    if (prev && prev.start === ch.start) {
+      // Prefer the titled copy when the same instant appears twice.
+      if (!prev.title && ch.title) prev.title = ch.title;
+      continue;
+    }
+    deduped.push({ start: ch.start, title: ch.title });
+  }
+  if (deduped.length < 2) return null;
+  // YouTube only promotes a description list that opens at 0:00. Official
+  // markers already satisfy that; a regex parse of prose should too, or
+  // "released at 3:00" + "ends 4:15" becomes two fake chapters.
+  if (deduped[0].start > 1) return null;
+  return deduped.map((ch, i) => ({
+    start: ch.start,
+    title: ch.title || `Chapter ${i + 1}`,
+  }));
+}
+
+function walk(node: unknown, visit: (n: YtNode) => void): void {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const child of node) walk(child, visit);
+    return;
+  }
+  const n = node as YtNode;
+  visit(n);
+  for (const v of Object.values(n)) walk(v, visit);
+}

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -89,7 +89,10 @@ export function shouldPersistQuery(queryKey: readonly unknown[]): boolean {
     // `staleTime: ONE_HOUR` in `useLyricsSources` still triggers a
     // background revalidate so newly-added LRCLIB entries surface
     // within an hour of the next play.
-    head === "lyrics"
+    head === "lyrics" ||
+    // Chapter lists are tiny and change rarely; persisting them makes
+    // the Chapters tab appear instantly on a repeat play of an OST.
+    head === "chapters"
   );
 }
 


### PR DESCRIPTION
## Summary
- Extract `PlayerMediaPanel` so the side player and the bottom-bar lyrics popover render the same surface (this used to be #71).
- Fetch YouTube chapters from the anonymous WEB `/player` (official `chapterRenderer` / `markersMap` first, then the description timestamp list YouTube itself promotes to chapters).
- When a track has at least two chapters, the panel grows Lyrics / Chapters tabs and defaults to Chapters. Clicking a row seeks.
- Persist the tiny chapter lists so OSTs reopen instantly.
- `formatTime` now supports hour-long timestamps (`1:31:29`) via a shared `formatTimestamp`.

## Why
OST dumps, long mixes, and uploaded concerts already have clickable chapter lists on YouTube. YT Music's WEB_REMIX `/next` and `/player` do not carry them (verified against a 152-chapter OST), so this uses the regular YouTube WEB client, unsigned — same rationale as YTM lyrics.

The shared panel is in the same PR because chapters hang Lyrics / Chapters tabs on it. Splitting that extract out as #71 made the stack noisier than the change is worth.

## Scope
Frontend-only, rebased cleanly on `v0.4.4` / current `origin/main`. One branch: `feature/chapters` (2 commits).

## Test plan
- [x] `pnpm test` (includes `chapters.test.ts` + `format.test.ts`)
- [x] `tsc --noEmit`
- [ ] Side player: lyrics still flow under the cover; source picker still in the bottom row
- [ ] Bottom-bar lyrics popover: title + source picker + lyrics body
- [ ] Play a chaptered OST (e.g. a game soundtrack upload with a `0:00` track list) — Chapters tab appears and is selected
- [ ] Click a chapter — playback seeks; the active row tracks the playhead / scrubber
- [ ] Play a normal song with no chapters — panel is still just lyrics, no tabs
- [ ] Replay the same OST after a restart — Chapters tab appears immediately from cache
- [ ] Side player and bottom-bar popover both show the same tabs

## Notes
Supersedes #71. Independent of the macOS / WEB_REMIX / speed / Share (#73) PRs. No cookies are sent to `www.youtube.com`.
