### PR TITLE
feat(player): add Share to the track menu

### DIFF
--- a/src/components/layout/player-more-menu.tsx
+++ b/src/components/layout/player-more-menu.tsx
@@ -56,8 +56,8 @@ type Props = {
  * Triple-dot overflow menu for the player surfaces. Wraps the same
  * `TrackMenuItems` block used by the right-click context menu on
  * track rows, so the actions (Play next, Add to queue, Start radio,
- * Like / Remove from liked, Add to playlist, Go to artist) stay in
- * sync between every entry point.
+ * Like / Remove from liked, Add to playlist, Go to artist, Share)
+ * stay in sync between every entry point.
  *
  * Splits into a main-window branch (uses `useNavigate` directly) and
  * a floating-window branch (emits a Tauri event so the main window

--- a/src/components/shared/track-context-menu.tsx
+++ b/src/components/shared/track-context-menu.tsx
@@ -22,8 +22,10 @@ import {
   PlusIcon,
   MoreHorizontalIcon,
   Loader2Icon,
+  Share2Icon,
 } from "lucide-react";
 import { toast } from "sonner";
+import { copyToClipboard, trackShareUrl } from "@/lib/clipboard";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -401,6 +403,19 @@ export function TrackMenuItems({
           Go to album
         </Item>
       )}
+
+      <Separator />
+
+      <Item
+        onSelect={async () => {
+          const ok = await copyToClipboard(trackShareUrl(item.id));
+          if (ok) toast.success("Link copied to clipboard");
+          else toast.error("Couldn't copy the link");
+        }}
+      >
+        <Share2Icon />
+        Share
+      </Item>
     </>
   );
 }

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,30 @@
+/**
+ * Copy text to the clipboard. `navigator.clipboard` is the happy path;
+ * some WebView contexts refuse it, so we fall back to a hidden textarea
+ * + `execCommand("copy")` the same way the artist-page Share button does.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    try {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      const ok = document.execCommand("copy");
+      ta.remove();
+      return ok;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/** Canonical share URL for a song/video row. */
+export function trackShareUrl(videoId: string): string {
+  return `https://music.youtube.com/watch?v=${videoId}`;
+}


### PR DESCRIPTION
## Summary
- Add a **Share** item to the track menu (right-click on a row and the player overflow). It copies `https://music.youtube.com/watch?v=<id>` to the clipboard.
- Extract `copyToClipboard` with a hidden-textarea + `execCommand("copy")` fallback for WebViews that block `navigator.clipboard` — the same path the artist-page Share button already uses.

## Why
Artist pages already have Share. Songs and videos did not, so the only way to grab a link was to leave the app.

## Scope
Frontend-only, rebased cleanly on `v0.4.4` / current `origin/main`. Independent of the lyrics (#71), chapters (#72), macOS, WEB_REMIX, and speed PRs.

## Test plan
- [x] `tsc --noEmit`
- [ ] Right-click a track → Share → paste is a `music.youtube.com/watch?v=…` URL
- [ ] Player ⋯ menu → Share — same toast and same URL
- [ ] Toast is "Link copied to clipboard" on success

## Notes
Does not change the artist-page Share button; that already copies the channel URL.
