### PR TITLE
feat(ytdlp): add a Stable/Nightly release-channel setting

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2684,8 +2684,9 @@ async fn set_cache_meta(
 /// state event fires; also serves as the retry path after a failed
 /// download. Idempotent — see `ytdlp::ensure`.
 #[tauri::command]
-async fn ensure_ytdlp(app: tauri::AppHandle) {
-    ytdlp::ensure(app).await;
+async fn ensure_ytdlp(app: tauri::AppHandle, channel: Option<String>) {
+    let nightly = channel.as_deref() == Some("nightly");
+    ytdlp::ensure(app, nightly).await;
 }
 
 /// Run yt-dlp to resolve a videoId into metadata JSON.
@@ -2703,7 +2704,7 @@ fn resolve_stream_ytdlp(app: tauri::AppHandle, video_id: String) -> Result<Strin
         "--no-playlist",
         "--no-warnings",
         "--extractor-args",
-        "youtube:player_client=tv,android_vr",
+        "youtube:player_client=default",
         &url,
     ]);
     // Windows: a console-less GUI process spawning the console-subsystem
@@ -2741,8 +2742,8 @@ type DownloadMap = Arc<Mutex<HashMap<String, Arc<DownloadState>>>>;
 // search, liked songs). We deliberately do NOT forward cookies to
 // yt-dlp: YouTube's bot-detection treats any authenticated yt-dlp
 // request as a bot and strips every real audio format, leaving only
-// storyboard thumbnails — so anonymous streaming via the android_vr/
-// ios/mweb clients actually works better than authenticated streaming.
+// storyboard thumbnails — so anonymous streaming via the default
+// client actually works better than authenticated streaming.
 #[derive(Clone)]
 struct StreamServer {
     /// Persistent cache. Tracks land here for Premium-authenticated
@@ -3102,7 +3103,7 @@ fn spawn_downloader(
             "--socket-timeout",
             "15",
             "--extractor-args",
-            "youtube:player_client=tv,android_vr",
+            "youtube:player_client=default",
             "-o",
             "-",
         ]);

--- a/src-tauri/src/ytdlp.rs
+++ b/src-tauri/src/ytdlp.rs
@@ -1,11 +1,11 @@
 //! Managed yt-dlp binary lifecycle.
 //!
-//! End users don't have yt-dlp on PATH, so the app owns its copy: the
-//! official single-file release is downloaded into
-//! `<app-data>/bin/yt-dlp.exe` on first run and self-updated via
-//! `yt-dlp -U` on a 72-hour cadence. The managed copy is canonical —
-//! PATH is only a fallback for dev machines while the download hasn't
-//! happened (or failed).
+//! End users don't have yt-dlp on PATH, so the app owns its copy: each
+//! release channel's build is downloaded under `<app-data>/bin/` on first
+//! use and refreshed on a 72-hour cadence, and the selected channel is
+//! copied over `yt-dlp` — the binary the stream server spawns. PATH is
+//! only a fallback for dev machines while the download hasn't happened
+//! (or failed).
 //!
 //! Streaming resilience depends on this: YouTube regularly breaks
 //! extractors and yt-dlp ships fixes within days, so the binary must
@@ -26,20 +26,32 @@ const BINARY_NAME: &str = "yt-dlp";
 /// the newest release asset, so no GitHub API call (and no rate limit)
 /// is involved.
 #[cfg(windows)]
-const DOWNLOAD_URL: &str =
-    "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe";
+const ASSET: &str = "yt-dlp.exe";
 #[cfg(target_os = "macos")]
-const DOWNLOAD_URL: &str =
-    "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos";
+const ASSET: &str = "yt-dlp_macos";
 #[cfg(all(unix, not(target_os = "macos")))]
-const DOWNLOAD_URL: &str =
-    "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp";
+const ASSET: &str = "yt-dlp";
 
-/// How often to let the managed binary check for its own update.
+fn channel_str(nightly: bool) -> &'static str {
+    if nightly {
+        "nightly"
+    } else {
+        "stable"
+    }
+}
+
+fn download_url(nightly: bool) -> String {
+    let repo = if nightly {
+        "yt-dlp/yt-dlp-nightly-builds"
+    } else {
+        "yt-dlp/yt-dlp"
+    };
+    format!("https://github.com/{repo}/releases/latest/download/{ASSET}")
+}
+
+/// How often to re-download a channel's build to keep it fresh.
 const UPDATE_INTERVAL: Duration = Duration::from_secs(72 * 60 * 60);
-/// Hard cap on the `-U` self-update run.
-const UPDATE_TIMEOUT: Duration = Duration::from_secs(180);
-/// Hard cap on the first-run download (the exe is ~12 MB).
+/// Hard cap on the download (the exe is ~12 MB).
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
 #[cfg(windows)]
@@ -52,6 +64,14 @@ pub fn managed_path(app: &tauri::AppHandle) -> PathBuf {
         .unwrap_or_else(|_| std::env::temp_dir())
         .join("bin")
         .join(BINARY_NAME)
+}
+
+fn channel_path(app: &tauri::AppHandle, nightly: bool) -> PathBuf {
+    #[cfg(windows)]
+    let name = format!("yt-dlp-{}.exe", channel_str(nightly));
+    #[cfg(not(windows))]
+    let name = format!("yt-dlp-{}", channel_str(nightly));
+    managed_path(app).with_file_name(name)
 }
 
 /// Program to spawn: the managed copy when present, otherwise bare
@@ -79,38 +99,44 @@ fn emit_state(app: &tauri::AppHandle, phase: &str, message: Option<String>) {
 /// re-invoke as a retry after a failed download.
 ///
 /// Emits `ytdlp-state` events: `downloading` → `ready` | `error`.
-pub async fn ensure(app: tauri::AppHandle) {
+pub async fn ensure(app: tauri::AppHandle, nightly: bool) {
     // Serialize concurrent calls (StrictMode double-mount, retry spam).
     static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
     let _guard = LOCK.lock().await;
 
-    let managed = managed_path(&app);
+    let active = managed_path(&app);
+    let cached = channel_path(&app, nightly);
 
-    if managed.exists() {
+    if cached.exists() && stamp_age(&cached).is_some_and(|age| age < UPDATE_INTERVAL) {
+        let _ = activate(&cached, &active).await;
         emit_state(&app, "ready", None);
-        maybe_self_update(&managed).await;
         return;
     }
 
     // Dev fallback: a working PATH install means we can play right now.
-    // Still fetch the managed copy in the background so this install
-    // stops depending on the machine's PATH from the next launch on.
-    let path_works = probe_path_install().await;
+    // Still fetch the managed copy so this install stops depending on the
+    // machine's PATH from the next launch on.
+    let path_works = !cached.exists() && !active.exists() && probe_path_install().await;
     if path_works {
         emit_state(&app, "ready", None);
     } else {
         emit_state(&app, "downloading", None);
     }
 
-    match download(&managed).await {
+    match download(&cached, nightly).await {
         Ok(()) => {
-            eprintln!("[ytdlp] downloaded managed binary to {managed:?}");
-            touch_update_stamp(&managed);
+            touch_stamp(&cached);
+            let _ = activate(&cached, &active).await;
             emit_state(&app, "ready", None);
         }
         Err(e) => {
             eprintln!("[ytdlp] download failed: {e}");
-            if !path_works {
+            if cached.exists() {
+                let _ = activate(&cached, &active).await;
+            }
+            if active.exists() || path_works {
+                emit_state(&app, "ready", None);
+            } else {
                 emit_state(&app, "error", Some(e));
             }
         }
@@ -131,20 +157,20 @@ async fn probe_path_install() -> bool {
     }
 }
 
-/// Fetch the official binary into `<managed>.part`, then rename. The
-/// .part indirection means a torn download never masquerades as a
-/// working binary.
-async fn download(managed: &Path) -> Result<(), String> {
-    if let Some(dir) = managed.parent() {
+/// Fetch the binary into `<dest>.part`, then rename. The .part
+/// indirection means a torn download never masquerades as a working
+/// binary.
+async fn download(dest: &Path, nightly: bool) -> Result<(), String> {
+    if let Some(dir) = dest.parent() {
         tokio::fs::create_dir_all(dir)
             .await
             .map_err(|e| format!("mkdir {dir:?}: {e}"))?;
     }
-    let part = managed.with_extension("part");
+    let part = dest.with_extension("part");
     let _ = tokio::fs::remove_file(&part).await;
 
     let fetch = async {
-        let resp = reqwest::get(DOWNLOAD_URL)
+        let resp = reqwest::get(download_url(nightly))
             .await
             .map_err(|e| format!("request: {e}"))?
             .error_for_status()
@@ -200,25 +226,25 @@ async fn download(managed: &Path) -> Result<(), String> {
         .await;
     }
 
-    tokio::fs::rename(&part, managed)
+    tokio::fs::rename(&part, dest)
         .await
         .map_err(|e| format!("rename: {e}"))
 }
 
-fn update_stamp_path(managed: &Path) -> PathBuf {
-    managed.with_file_name("last-update-check")
+fn stamp_path(bin: &Path) -> PathBuf {
+    bin.with_extension("stamp")
 }
 
-fn touch_update_stamp(managed: &Path) {
+fn touch_stamp(bin: &Path) {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    let _ = std::fs::write(update_stamp_path(managed), now.to_string());
+    let _ = std::fs::write(stamp_path(bin), now.to_string());
 }
 
-fn update_stamp_age(managed: &Path) -> Option<Duration> {
-    let raw = std::fs::read_to_string(update_stamp_path(managed)).ok()?;
+fn stamp_age(bin: &Path) -> Option<Duration> {
+    let raw = std::fs::read_to_string(stamp_path(bin)).ok()?;
     let then = raw.trim().parse::<u64>().ok()?;
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -227,42 +253,8 @@ fn update_stamp_age(managed: &Path) -> Option<Duration> {
     Some(Duration::from_secs(now.saturating_sub(then)))
 }
 
-/// Run `yt-dlp -U` on the managed copy when the last check is older
-/// than `UPDATE_INTERVAL`. The official release binary replaces itself
-/// in place. The stamp is refreshed even on failure so a broken update
-/// path can't turn into a retry storm on every launch.
-async fn maybe_self_update(managed: &Path) {
-    match update_stamp_age(managed) {
-        Some(age) if age < UPDATE_INTERVAL => return,
-        _ => {}
-    }
-    touch_update_stamp(managed);
-
-    let mut cmd = tokio::process::Command::new(managed);
-    cmd.arg("-U");
-    #[cfg(windows)]
-    cmd.creation_flags(CREATE_NO_WINDOW);
-    cmd.stdout(std::process::Stdio::piped());
-    cmd.stderr(std::process::Stdio::piped());
-    // The timeout below drops the output() future — without this the
-    // wedged child would outlive it as an orphan.
-    cmd.kill_on_drop(true);
-
-    let run = async {
-        match cmd.output().await {
-            Ok(out) => {
-                let stdout = String::from_utf8_lossy(&out.stdout);
-                let line = stdout
-                    .lines()
-                    .rev()
-                    .find(|l| !l.trim().is_empty())
-                    .unwrap_or("");
-                eprintln!("[ytdlp] self-update ({}): {line}", out.status);
-            }
-            Err(e) => eprintln!("[ytdlp] self-update spawn failed: {e}"),
-        }
-    };
-    if tokio::time::timeout(UPDATE_TIMEOUT, run).await.is_err() {
-        eprintln!("[ytdlp] self-update timed out");
-    }
+async fn activate(cached: &Path, active: &Path) -> std::io::Result<()> {
+    let tmp = active.with_extension("swap");
+    tokio::fs::copy(cached, &tmp).await?;
+    tokio::fs::rename(&tmp, active).await
 }

--- a/src/components/settings/storage-tab.tsx
+++ b/src/components/settings/storage-tab.tsx
@@ -8,6 +8,7 @@ import {
   CalendarClockIcon,
   ChevronDownIcon,
   DatabaseIcon,
+  DownloadIcon,
   FolderIcon,
   FolderOpenIcon,
   HardDriveIcon,
@@ -56,6 +57,7 @@ export function StorageTab() {
       <StorageStats />
       <TabPane>
         <CacheFolderGroup />
+        <AudioEngineGroup />
         {/* Auto-clean lives outside the premium-gated tracks group: the
             sweep prunes whatever is already on disk, so it stays useful
             (and visible) even when caching itself is gated off. */}
@@ -67,6 +69,30 @@ export function StorageTab() {
         <CacheGroupGate loggedIn={!!loggedIn.data} />
       </TabPane>
     </>
+  );
+}
+
+function AudioEngineGroup() {
+  const channel = useSettingsStore((s) => s.ytdlpChannel);
+  const setChannel = useSettingsStore((s) => s.setYtdlpChannel);
+  return (
+    <Group>
+      <SettingRow
+        icon={DownloadIcon}
+        title="yt-dlp updates"
+        description="Nightly builds fix YouTube playback breakage sooner. Switch to Nightly only if you're having playback problems."
+        control={
+          <SegmentedControl
+            value={channel}
+            onChange={setChannel}
+            options={[
+              { value: "stable", label: "Stable" },
+              { value: "nightly", label: "Nightly" },
+            ]}
+          />
+        }
+      />
+    </Group>
   );
 }
 

--- a/src/lib/audio-engine.ts
+++ b/src/lib/audio-engine.ts
@@ -184,6 +184,8 @@ export function useAudioEngine() {
   // sit silent until the user re-picked it.
   const premiumOk = usePremiumStore((s) => s.status === "premium");
 
+  const streamResolveNonce = usePlaybackStore((s) => s.streamResolveNonce);
+
   useEffect(() => {
     const el = audioRef.current;
     if (!el) return;
@@ -281,7 +283,7 @@ export function useAudioEngine() {
     // (sign-in, status re-check) re-resolves a track the gate parked.
     // `retryNonce` so the error handler can force a fresh stream-URL fetch
     // for the current track after a transient failure without changing id.
-  }, [streamVideoId, videoId, index, premiumOk, retryNonce]);
+  }, [streamVideoId, videoId, index, premiumOk, retryNonce, streamResolveNonce]);
 
   // Play / pause follow store.
   const playing = usePlaybackStore((s) => s.playing);

--- a/src/lib/store/playback.ts
+++ b/src/lib/store/playback.ts
@@ -36,6 +36,7 @@ export type PlaybackState = {
   error?: string;
   /** Resolved stream URL for the current track (set by AudioEngine). */
   streamUrl?: string;
+  streamResolveNonce: number;
 
   // Transport
   playing: boolean;
@@ -83,6 +84,7 @@ export type PlaybackState = {
   // Actions — status (used by AudioEngine)
   setStatus: (status: LoadStatus, error?: string) => void;
   setStreamUrl: (url?: string) => void;
+  reresolveStream: () => void;
   setPosition: (position: number) => void;
   setDuration: (duration: number) => void;
   seek: (seconds: number) => void;
@@ -175,6 +177,7 @@ const playbackStateCreator: StateCreator<PlaybackState> = (set, get) => ({
   status: "idle",
   error: undefined,
   streamUrl: undefined,
+  streamResolveNonce: 0,
 
   playing: false,
   volume: 0.8,
@@ -432,6 +435,8 @@ const playbackStateCreator: StateCreator<PlaybackState> = (set, get) => ({
 
   setStatus: (status, error) => set({ status, error }),
   setStreamUrl: (streamUrl) => set({ streamUrl }),
+  reresolveStream: () =>
+    set((s) => ({ streamResolveNonce: s.streamResolveNonce + 1 })),
   setPosition: (position) => set({ position }),
   setDuration: (duration) => set({ duration }),
   seek: (seconds) =>

--- a/src/lib/store/settings.ts
+++ b/src/lib/store/settings.ts
@@ -6,6 +6,7 @@ import { persist } from "zustand/middleware";
 export type CloseButtonAction = "tray" | "quit";
 export type CacheAutoCleanPeriod = "off" | "daily" | "weekly" | "monthly";
 export type BackgroundMode = "ambient" | "plain";
+export type YtdlpChannel = "stable" | "nightly";
 
 type State = {
   /** What the title-bar ✕ does: hide to tray (default) or quit. */
@@ -43,6 +44,7 @@ type State = {
    *  scrobbling and off by default: an opt-in, since people often keep their
    *  likes intentionally different per platform. See `lib/lastfm.ts`. */
   lastfmLoveSync: boolean;
+  ytdlpChannel: YtdlpChannel;
   setCloseAction: (v: CloseButtonAction) => void;
   setCacheAutoClean: (v: CacheAutoCleanPeriod) => void;
   markCacheCleaned: () => void;
@@ -51,6 +53,7 @@ type State = {
   setDiscordRichPresence: (v: boolean) => void;
   setLastfmEnabled: (v: boolean) => void;
   setLastfmLoveSync: (v: boolean) => void;
+  setYtdlpChannel: (v: YtdlpChannel) => void;
   setLastfmAvatar: (v: string | null) => void;
   /** Store the account returned by the connect flow and enable scrobbling. */
   setLastfmSession: (username: string, sessionKey: string) => void;
@@ -78,6 +81,7 @@ export const useSettingsStore = create<State>()(
       lastfmUsername: null,
       lastfmAvatar: null,
       lastfmLoveSync: false,
+      ytdlpChannel: "stable",
       setCloseAction: (closeAction) => set({ closeAction }),
       setCacheAutoClean: (cacheAutoClean) => set({ cacheAutoClean }),
       markCacheCleaned: () => set({ lastCacheCleanAt: Date.now() }),
@@ -88,6 +92,7 @@ export const useSettingsStore = create<State>()(
         set({ discordRichPresence }),
       setLastfmEnabled: (lastfmEnabled) => set({ lastfmEnabled }),
       setLastfmLoveSync: (lastfmLoveSync) => set({ lastfmLoveSync }),
+      setYtdlpChannel: (ytdlpChannel) => set({ ytdlpChannel }),
       setLastfmAvatar: (lastfmAvatar) => set({ lastfmAvatar }),
       setLastfmSession: (lastfmUsername, lastfmSessionKey) =>
         set({ lastfmUsername, lastfmSessionKey, lastfmEnabled: true }),

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { toast } from "sonner";
+import { useSettingsStore } from "@/lib/store/settings";
+import { usePlaybackStore } from "@/lib/store/playback";
 
 type YtdlpState = {
   phase: "downloading" | "ready" | "error";
@@ -24,6 +26,8 @@ const TOAST_ID = "ytdlp-setup";
 export function useYtdlpSetup(): void {
   // True only after a "downloading" event — gates the success toast.
   const sawDownloadRef = useRef(false);
+  const channel = useSettingsStore((s) => s.ytdlpChannel);
+  const firstRunRef = useRef(true);
 
   useEffect(() => {
     let cancelled = false;
@@ -51,7 +55,7 @@ export function useYtdlpSetup(): void {
           action: {
             label: "Retry",
             onClick: () => {
-              void invoke("ensure_ytdlp");
+              void invoke("ensure_ytdlp", { channel });
             },
           },
         });
@@ -63,14 +67,21 @@ export function useYtdlpSetup(): void {
       }
       dispose = un;
       // Listener is live — safe to start the Rust side now.
-      void invoke("ensure_ytdlp").catch((err) => {
-        console.error("[ytdlp] ensure_ytdlp failed:", err);
-      });
+      void invoke("ensure_ytdlp", { channel })
+        .then(() => {
+          if (!firstRunRef.current) {
+            usePlaybackStore.getState().reresolveStream();
+          }
+          firstRunRef.current = false;
+        })
+        .catch((err) => {
+          console.error("[ytdlp] ensure_ytdlp failed:", err);
+        });
     });
 
     return () => {
       cancelled = true;
       dispose?.();
     };
-  }, []);
+  }, [channel]);
 }


### PR DESCRIPTION
# Add a Stable/Nightly yt-dlp release-channel setting

## Problem

<img width="auto" height="540" alt="image" src="https://github.com/user-attachments/assets/6f9bf43e-630f-4bf0-84cc-b6be388abcfb" />

YouTube now gates audio downloads behind a GVS PO token. The pinned
`tv,android_vr` client on the stable yt-dlp channel can't produce a downloadable
stream, so playback 403s on every track.

## Changes

- **Client:** `player_client=tv,android_vr` → `default`, letting yt-dlp pick a
  PO-token-free client (e.g. `visionos`).
- **Setting:** Stable / Nightly selector in **Settings → Storage**. Default: Stable.
- **Per-channel binaries:** each channel is cached as `bin/yt-dlp-<channel>`; the
  selected one is copied over `bin/yt-dlp` — the binary the stream server spawns.
- **Switching:** an instant local copy. No re-download after the first fetch of a
  channel.
- **Immediate:** changing the channel re-resolves the current track, so it applies
  without skipping.
- **Updates:** dropped `yt-dlp -U` (hit `api.github.com`) in favor of a direct
  re-download from the channel's `releases/latest/download`, refreshed every 72h.

## Behavior

- **Stable** — latest tagged yt-dlp. May 403 until a fix lands in a stable release.
- **Nightly** — gets YouTube fixes first. Switch here if playback breaks.

Streaming stays anonymous (no cookies sent to yt-dlp).

## Testing

1. Play a track.
2. Settings → Storage → toggle Stable / Nightly.
3. Stable 403-fails, Nightly plays. First pick of each channel downloads once;
   later toggles are instant.