### PR TITLE
feat(now-playing): add immersive full-screen karaoke overlay

### DIFF
--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -8,6 +8,7 @@ import { AppSidebar } from "@/components/layout/app-sidebar";
 import { TopBar } from "@/components/layout/top-bar";
 import { PlayerBar } from "@/components/layout/player-bar";
 import { PlayerBarBottom } from "@/components/layout/player-bar-bottom";
+import { NowPlayingOverlay } from "@/components/layout/now-playing-overlay";
 import { FloatingPlayerSync } from "@/components/layout/floating-player-sync";
 import { DragSnapOverlay } from "@/components/layout/drag-snap-overlay";
 import { WindowResizeHandles } from "@/components/layout/window-resize-handles";
@@ -34,6 +35,7 @@ import { useWhatsNewOnUpdate } from "@/lib/store/whats-new";
 import { pickHighResThumbnail } from "@/components/shared/thumbnail";
 import { usePlaybackStore, currentTrack } from "@/lib/store/playback";
 import { useLayoutStore } from "@/lib/store/layout";
+import { useNowPlayingStore } from "@/lib/store/now-playing";
 import { usePremiumStatusSync } from "@/lib/store/premium";
 import {
   useCloseBehaviorSync,
@@ -109,6 +111,7 @@ export function AppShell({ children }: { children: ReactNode }) {
   const sidebarWidth = useLayoutStore((s) => s.sidebarWidth);
   const playerWidth = useLayoutStore((s) => s.playerWidth);
   const background = useSettingsStore((s) => s.background);
+  const nowPlayingOpen = useNowPlayingStore((s) => s.open);
   // The player UI is hidden whenever there's no active track —
   // covers the "Nothing playing" empty state at first launch and
   // after the queue is cleared. The mode itself stays the same; the
@@ -129,6 +132,21 @@ export function AppShell({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (mainRef.current) mainRef.current.scrollTop = 0;
   }, [pathname]);
+
+  // While the (body-portaled) overlay is open, mark the content area `inert`
+  // for modal focus. The content row, not the root, so the title bar's drag +
+  // window controls stay live. Layout effect so it clears synchronously before
+  // the overlay restores focus, which would otherwise hit an inert element.
+  const contentRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    if (contentRef.current) contentRef.current.inert = nowPlayingOpen;
+  }, [nowPlayingOpen]);
+
+  // Reset the flag when the queue empties — unmounting alone would leave it
+  // `true`, popping the overlay back open on the next track.
+  useEffect(() => {
+    if (!hasTrack) useNowPlayingStore.getState().setOpen(false);
+  }, [hasTrack]);
 
   // Open / close the floating player window. We only spawn it when
   // there's actually something to show — at first launch with mode
@@ -218,7 +236,7 @@ export function AppShell({ children }: { children: ReactNode }) {
               Windows-style min/max/close buttons land in the actual
               top-right corner, not behind the floating player. */}
           <TopBar />
-          <div className="relative flex min-h-0 flex-1">
+          <div ref={contentRef} className="relative flex min-h-0 flex-1">
             <AppSidebar />
             <SidebarResizeHandle />
             {/* In `right` mode we reserve 23rem on the right for the
@@ -264,6 +282,7 @@ export function AppShell({ children }: { children: ReactNode }) {
           <ChannelPickerDialog />
           <WhatsNewDialog />
         </div>
+        {hasTrack && nowPlayingOpen && <NowPlayingOverlay />}
       </SidebarProvider>
       <Toaster />
     </TooltipProvider>

--- a/src/components/layout/now-playing-overlay.tsx
+++ b/src/components/layout/now-playing-overlay.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { motion, useReducedMotion } from "motion/react";
+import {
+  PlayIcon,
+  PauseIcon,
+  SkipBackIcon,
+  SkipForwardIcon,
+  ShuffleIcon,
+  RepeatIcon,
+  Repeat1Icon,
+  Loader2Icon,
+  ChevronDownIcon,
+} from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  ProgressSlider,
+  VolumeControl,
+  formatTime,
+  repeatLabel,
+  useITunesCover,
+} from "@/components/layout/player-bar";
+import {
+  LyricsBody,
+  LyricsSourceButton,
+  useLyricsView,
+} from "@/components/layout/lyrics-view";
+import { Thumbnail, pickHighResThumbnail } from "@/components/shared/thumbnail";
+import { ArtworkOutline } from "@/components/shared/artwork-outline";
+import { ArtistLinks } from "@/components/shared/artist-links";
+import { LikeDislikeButtons } from "@/components/shared/like-buttons";
+import { PlayerMoreMenu } from "@/components/layout/player-more-menu";
+import { usePlaybackStore, currentTrack } from "@/lib/store/playback";
+import { useScrubStore } from "@/lib/store/scrub";
+import { useNowPlayingStore } from "@/lib/store/now-playing";
+import { cn } from "@/lib/utils";
+
+// Immersive full-window "Now Playing" screen: full-size cover left, synced
+// karaoke lyrics right. Reuses the playback/scrub stores, the player-bar
+// transport bits, and the LyricsBody/useLyricsView engine — only layout is new.
+export function NowPlayingOverlay() {
+  const { playing, status, position, duration, shuffle, repeat } =
+    usePlaybackStore(
+      useShallow((s) => ({
+        playing: s.playing,
+        status: s.status,
+        position: s.position,
+        duration: s.duration,
+        shuffle: s.shuffle,
+        repeat: s.repeat,
+      })),
+    );
+  const track = usePlaybackStore(currentTrack);
+  const toggle = usePlaybackStore((s) => s.toggle);
+  const next = usePlaybackStore((s) => s.next);
+  const prev = usePlaybackStore((s) => s.prev);
+  const seek = usePlaybackStore((s) => s.seek);
+  const setShuffle = usePlaybackStore((s) => s.setShuffle);
+  const cycleRepeat = usePlaybackStore((s) => s.cycleRepeat);
+
+  const scrub = useScrubStore((s) => s.scrub);
+  const setScrub = useScrubStore((s) => s.setScrub);
+  const setOpen = useNowPlayingStore((s) => s.setOpen);
+
+  const iTunesCover = useITunesCover(track);
+  const lyricsState = useLyricsView(track);
+  const reduce = useReducedMotion();
+
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+
+  // Esc closes + focus moves in on open, restored on close. The
+  // `defaultPrevented` guard lets Radix close an open menu/tooltip first.
+  useEffect(() => {
+    const prevFocused = document.activeElement as HTMLElement | null;
+    closeBtnRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.defaultPrevented) return;
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      prevFocused?.focus?.();
+    };
+  }, [setOpen]);
+
+  if (!track) return null;
+
+  const loading = status === "loading" && playing;
+  const coverUrl = pickHighResThumbnail(track.thumbnails);
+
+  const overlay = (
+    // Own provider: the overlay mounts inside SidebarProvider's delay=0 one.
+    <TooltipProvider delayDuration={800} skipDelayDuration={0}>
+      {/* `dark`: reused components stay legible over the dark backdrop.
+          `top-(--titlebar-h)`: keep the OS window controls usable. */}
+      <motion.div
+        role="region"
+        aria-label="Now playing"
+        initial={{ opacity: 0, scale: reduce ? 1 : 0.99 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: reduce ? 0.12 : 0.2, ease: "easeOut" }}
+        className="dark fixed inset-x-0 bottom-0 top-(--titlebar-h) z-40 flex flex-col overflow-hidden bg-background text-foreground"
+      >
+        {/* Blurred cover backdrop + scrim to keep lyrics readable over it. */}
+        {coverUrl ? (
+          <img
+            key={coverUrl}
+            src={coverUrl}
+            alt=""
+            aria-hidden
+            className="pointer-events-none absolute inset-0 h-full w-full scale-125 object-cover blur-3xl saturate-150 opacity-35"
+          />
+        ) : null}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 bg-black/55"
+        />
+
+        {/* Top bar — draggable strip (the title bar's own is behind the overlay). */}
+        <div
+          data-tauri-drag-region
+          className="relative flex shrink-0 items-center justify-end px-4 pt-4 pb-2"
+        >
+          <Button
+            ref={closeBtnRef}
+            variant="ghost"
+            size="icon"
+            aria-label="Close now playing"
+            onClick={() => setOpen(false)}
+            className="size-11 rounded-full bg-black/35 text-white shadow-sm ring-1 ring-white/15 backdrop-blur-md transition-colors hover:bg-black/60 hover:text-white"
+          >
+            <ChevronDownIcon className="size-7" />
+          </Button>
+        </div>
+
+        {/* Cover+controls left, lyrics right; stacks when narrow. Every lyrics
+            ancestor is a `min-h-0` flex column so its `h-full` scroller resolves. */}
+        <div className="relative flex min-h-0 flex-1 flex-col gap-6 px-6 pb-8 lg:flex-row lg:gap-10 lg:px-10">
+          {/* LEFT: cover + controls */}
+          <div className="flex min-h-0 flex-col items-center justify-center gap-5 lg:w-2/5">
+            <div className="relative isolate aspect-square w-full max-w-[min(70vw,38vh)] rounded-xl shadow-[0_8px_40px_rgb(0_0_0/0.45)] lg:max-w-[min(80vw,58vh)]">
+              <Thumbnail
+                thumbnails={track.thumbnails}
+                alt={track.title}
+                className="size-full rounded-xl pointer-events-none"
+                targetSize={1024}
+                highRes
+                overrideHighRes={iTunesCover}
+              />
+              <ArtworkOutline className="rounded-xl" />
+            </div>
+
+            {/* Title + artist + like */}
+            <div className="flex w-full max-w-xl items-start gap-3">
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate text-2xl font-semibold text-white [text-shadow:0_1px_3px_rgb(0_0_0/0.6)]">
+                  {track.title}
+                </span>
+                <ArtistLinks
+                  artists={track.artists}
+                  fallback={track.subtitle ?? ""}
+                  className="truncate text-base text-white/70 [text-shadow:0_1px_3px_rgb(0_0_0/0.6)]"
+                />
+              </div>
+              <LikeDislikeButtons
+                videoId={track.videoId}
+                track={track}
+                className="shrink-0"
+              />
+            </div>
+
+            {/* Progress */}
+            <div className="flex w-full max-w-xl flex-col gap-2">
+              <ProgressSlider
+                position={position}
+                duration={duration}
+                scrub={scrub}
+                setScrub={setScrub}
+                seek={seek}
+                disabled={duration <= 0}
+              />
+              <div className="flex justify-between text-xs tabular-nums text-white/70">
+                <span>{formatTime(scrub ?? position)}</span>
+                <span>{formatTime(duration)}</span>
+              </div>
+            </div>
+
+            {/* Transport — the player-bar cluster, inlined and scaled up. */}
+            <div className="flex items-center justify-center gap-2 text-white">
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Shuffle"
+                aria-pressed={shuffle}
+                onClick={() => setShuffle(!shuffle)}
+                className={cn("hover:bg-white/10", shuffle && "text-brand")}
+              >
+                <ShuffleIcon />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Previous"
+                onClick={prev}
+                className="hover:bg-white/10"
+              >
+                <SkipBackIcon className="fill-current" />
+              </Button>
+              <Button
+                size="icon"
+                aria-label={playing ? "Pause" : "Play"}
+                onClick={toggle}
+                className="size-14 rounded-full bg-brand text-white hover:bg-brand/90"
+              >
+                {loading ? (
+                  <Loader2Icon className="animate-spin" />
+                ) : playing ? (
+                  <PauseIcon className="fill-current" />
+                ) : (
+                  <PlayIcon className="fill-current" />
+                )}
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Next"
+                onClick={next}
+                className="hover:bg-white/10"
+              >
+                <SkipForwardIcon className="fill-current" />
+              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label={repeatLabel(repeat)}
+                    aria-pressed={repeat !== "off"}
+                    onClick={cycleRepeat}
+                    className={cn(
+                      "hover:bg-white/10",
+                      repeat !== "off" && "text-brand",
+                    )}
+                  >
+                    {repeat === "one" ? <Repeat1Icon /> : <RepeatIcon />}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{repeatLabel(repeat)}</TooltipContent>
+              </Tooltip>
+            </div>
+
+            {/* Volume + lyrics source + more */}
+            <div className="flex items-center justify-center gap-1">
+              <VolumeControl />
+              <LyricsSourceButton state={lyricsState} />
+              <PlayerMoreMenu track={track} />
+            </div>
+          </div>
+
+          {/* RIGHT: synced lyrics. `np-lyrics` scopes the overlay overrides
+              (index.css); text-shadow is a contrast safety net over the scrim. */}
+          <div className="flex min-h-0 flex-1 flex-col lg:w-3/5">
+            <div className="np-lyrics min-h-0 flex-1 [text-shadow:0_1px_3px_rgb(0_0_0/0.55)]">
+              <LyricsBody state={lyricsState} />
+            </div>
+          </div>
+        </div>
+      </motion.div>
+    </TooltipProvider>
+  );
+
+  return createPortal(overlay, document.body);
+}

--- a/src/components/layout/player-bar-bottom.tsx
+++ b/src/components/layout/player-bar-bottom.tsx
@@ -8,6 +8,7 @@ import {
   Repeat1Icon,
   Loader2Icon,
   MicVocalIcon,
+  Maximize2Icon,
 } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -45,6 +46,7 @@ import { cn } from "@/lib/utils";
 import { usePlayerCoverDrag } from "@/lib/player-drag";
 import { usePlaybackStore, currentTrack } from "@/lib/store/playback";
 import { useScrubStore } from "@/lib/store/scrub";
+import { useNowPlayingStore } from "@/lib/store/now-playing";
 
 /**
  * Compact horizontal player bar pinned to the bottom of the content
@@ -133,7 +135,7 @@ export function PlayerBarBottom() {
               className="shrink-0 touch-none select-none cursor-grab active:cursor-grabbing"
             >
               {track ? (
-                <div className="relative isolate size-14 shrink-0">
+                <div className="group relative isolate size-14 shrink-0">
                   <Thumbnail
                     thumbnails={track.thumbnails}
                     alt={track.title}
@@ -143,6 +145,16 @@ export function PlayerBarBottom() {
                     overrideHighRes={iTunesCover}
                   />
                   <ArtworkOutline className="rounded-md" />
+                  {/* Too small for a corner button — full-cover scrim on hover. */}
+                  <button
+                    type="button"
+                    aria-label="Open now playing"
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={() => useNowPlayingStore.getState().setOpen(true)}
+                    className="pointer-events-auto absolute inset-0 z-10 flex items-center justify-center rounded-md bg-black/45 text-white opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                  >
+                    <Maximize2Icon className="size-5" />
+                  </button>
                 </div>
               ) : (
                 <div className="size-14 shrink-0 rounded-md border border-hairline bg-muted" />

--- a/src/components/layout/player-bar.tsx
+++ b/src/components/layout/player-bar.tsx
@@ -13,6 +13,7 @@ import {
   Loader2Icon,
   MusicIcon,
   VideoIcon,
+  Maximize2Icon,
 } from "lucide-react";
 import { QueueBody, QueueToggleButton } from "@/components/layout/queue-panel";
 import {
@@ -42,6 +43,7 @@ import { cn } from "@/lib/utils";
 import { usePlayerCoverDrag } from "@/lib/player-drag";
 import { usePlaybackStore, currentTrack } from "@/lib/store/playback";
 import { useScrubStore } from "@/lib/store/scrub";
+import { useNowPlayingStore } from "@/lib/store/now-playing";
 import {
   useTrackSourceStore,
   type SourceKind,
@@ -567,7 +569,7 @@ export function PlayerBar({
               // it that group is the motion.div wrapping cover AND lyrics, so
               // the lyrics' backdrop-blur strip loses the card and the app
               // background from its backdrop and paints as a dark band.
-              <div className="relative isolate aspect-square w-full rounded-md shadow-[0_1px_14px_rgb(0_0_0/0.12)]">
+              <div className="group relative isolate aspect-square w-full rounded-md shadow-[0_1px_14px_rgb(0_0_0/0.12)]">
                 <Thumbnail
                   thumbnails={track.thumbnails}
                   alt={track.title}
@@ -577,6 +579,22 @@ export function PlayerBar({
                   overrideHighRes={iTunesCover}
                 />
                 <ArtworkOutline className="rounded-md" />
+                {/* Expand into the Now-Playing overlay (not in the floating
+                    window — no app shell there). `stopPropagation` keeps the
+                    click from starting the cover's drag. */}
+                {variant !== "floating" && (
+                  <button
+                    type="button"
+                    aria-label="Open now playing"
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={() =>
+                      useNowPlayingStore.getState().setOpen(true)
+                    }
+                    className="pointer-events-auto absolute right-2 top-2 flex size-8 items-center justify-center rounded-full bg-black/50 text-white opacity-0 transition-opacity hover:bg-black/70 group-hover:opacity-100 focus-visible:opacity-100"
+                  >
+                    <Maximize2Icon className="size-4" />
+                  </button>
+                )}
               </div>
             ) : (
               <div className="aspect-square w-full rounded-md border border-hairline bg-muted" />

--- a/src/index.css
+++ b/src/index.css
@@ -383,6 +383,25 @@
     backface-visibility: hidden;
   }
 
+  /* Now-Playing overlay lyrics — scoped to `.np-lyrics` so the compact
+     player card is untouched. Bigger, centered text; wider line spacing; the
+     top blur strip is dropped (it double-blurs against the overlay backdrop).
+     `.np-lyrics .lyrics-line` (0,2,0) outranks the line's `text-lg` (0,1,0). */
+  .np-lyrics .lyrics-line {
+    font-size: clamp(2.1rem, 3vw, 3.4rem);
+    line-height: 1.35;
+    padding-block: 0.5rem;
+    text-align: center;
+    transform-origin: center;
+  }
+  .np-lyrics .lyrics-no-scrollbar {
+    gap: 1.5rem;
+    padding-inline: 5%;
+  }
+  .np-lyrics .lyrics-blur-overlay {
+    display: none;
+  }
+
   /* Seeking. The 1.26s cross-fade is tuned for the slow handoff between
      two lines during playback; when the playhead is dragged it lags the
      text far behind the thumb. While a seek is in flight the same

--- a/src/lib/store/now-playing.ts
+++ b/src/lib/store/now-playing.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+type State = {
+  open: boolean;
+  setOpen: (v: boolean) => void;
+  toggle: () => void;
+};
+
+// Non-persisted so the overlay never survives a reload or leaks across
+// windows through the shared layout-storage key.
+export const useNowPlayingStore = create<State>()((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+  toggle: () => set((s) => ({ open: !s.open })),
+}));


### PR DESCRIPTION
A full-window "Now Playing" screen: full-size album cover on the left, centered full-size synced karaoke lyrics on the right, over a blurred copy of the cover. Opened by an expand button on the player cover (both the right card and the bottom bar), closed with its chevron-down button or Esc.

<img width="970" height="613" alt="image" src="https://github.com/user-attachments/assets/0e4c6abc-a9c8-4882-b315-c2bf9c508817" />

Reuses the existing player stack rather than adding new logic:
- the playback + scrub stores drive transport and the progress slider;
- ProgressSlider / VolumeControl / useITunesCover are imported from the player bar; the transport cluster is inlined (the two bars are left untouched so their differing layouts don't regress);
- the LyricsBody / useLyricsView karaoke engine already highlights the active line, auto-scrolls, and seeks on line click.

Details:
- New non-persisted store (now-playing.ts) holds the open flag, so it never survives a reload or leaks across windows via the shared layout key.
- Overlay is portaled to <body> and the app root is marked `inert` while open (background out of the tab order + a11y tree) - modal focus with focus-in/restore and no focus-trap library. Reused components are forced into a `dark` token context so they stay legible over the dark backdrop; a ~55% scrim + text-shadow keep lyrics readable over bright covers; reduced-motion is respected on the open animation.
- Positioned below the 36px title bar so the OS window controls stay usable; auto-closes (and resets the flag) when the queue empties; the expand button is suppressed in the floating window.