### PR TITLE
Add an in-app debug console for diagnosing playback and auth issues

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for the main window",
-  "windows": ["main", "player"],
+  "windows": ["main", "player", "diagnostics"],
   "permissions": [
     "core:default",
     "opener:default",

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -1,0 +1,92 @@
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+
+const CAPACITY: usize = 2000;
+
+#[derive(Clone, Serialize)]
+pub struct DiagLine {
+    at: u64,
+    tag: String,
+    text: String,
+}
+
+pub struct DiagState(Mutex<VecDeque<DiagLine>>);
+
+impl Default for DiagState {
+    fn default() -> Self {
+        DiagState(Mutex::new(VecDeque::with_capacity(CAPACITY)))
+    }
+}
+
+fn epoch_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+pub fn note(app: &AppHandle, tag: &str, text: impl Into<String>) {
+    let text = text.into();
+    eprintln!("[{tag}] {text}");
+    let line = DiagLine {
+        at: epoch_ms(),
+        tag: tag.to_string(),
+        text,
+    };
+    if let Some(state) = app.try_state::<DiagState>() {
+        let mut buf = state.0.lock().unwrap();
+        if buf.len() >= CAPACITY {
+            buf.pop_front();
+        }
+        buf.push_back(line.clone());
+    }
+    let _ = app.emit("diag-line", line);
+}
+
+#[tauri::command]
+pub fn diag_backlog(state: tauri::State<'_, DiagState>) -> Vec<DiagLine> {
+    state.0.lock().unwrap().iter().cloned().collect()
+}
+
+#[tauri::command]
+pub fn diag_log(app: AppHandle, tag: String, text: String) {
+    note(&app, &tag, text);
+}
+
+pub fn open(app: &AppHandle, browser_args: &str) {
+    if let Some(existing) = app.get_webview_window("diagnostics") {
+        let _ = existing.show();
+        let _ = existing.set_focus();
+        return;
+    }
+    let built = WebviewWindowBuilder::new(
+        app,
+        "diagnostics",
+        WebviewUrl::App("index.html?diagnostics=1".into()),
+    )
+    .title("YTubic diagnostics")
+    .inner_size(880.0, 560.0)
+    .min_inner_size(560.0, 360.0)
+    .resizable(true)
+    .additional_browser_args(browser_args)
+    .build();
+    if let Err(e) = built {
+        eprintln!("[diagnostics] window open failed: {e}");
+    }
+}
+
+#[tauri::command]
+pub async fn open_diag_window(app: AppHandle) {
+    open(&app, crate::APP_WEBVIEW_ARGS);
+}
+
+#[tauri::command]
+pub async fn close_diag_window(app: AppHandle) {
+    if let Some(win) = app.get_webview_window("diagnostics") {
+        let _ = win.close();
+    }
+}

--- a/src-tauri/src/lastfm.rs
+++ b/src-tauri/src/lastfm.rs
@@ -136,21 +136,20 @@ pub struct BeginAuth {
 
 /// `auth.getToken` → an unauthorized request token, plus the browser URL the
 /// user visits to approve it.
-async fn get_token(client: &reqwest::Client) -> Result<String, String> {
+async fn get_token(app: &AppHandle, client: &reqwest::Client) -> Result<String, String> {
     let mut params = BTreeMap::new();
     params.insert("method".into(), "auth.getToken".into());
     params.insert("api_key".into(), API_KEY.into());
     let params = finalize(params);
 
-    let body = client
+    let resp = client
         .get(API_ROOT)
         .query(&params)
         .send()
         .await
-        .map_err(|e| format!("network error: {e}"))?
-        .text()
-        .await
-        .map_err(|e| format!("read error: {e}"))?;
+        .map_err(|e| format!("network error: {e}"))?;
+    crate::diagnostics::note(app, "network", format!("lastfm auth.getToken {}", resp.status()));
+    let body = resp.text().await.map_err(|e| format!("read error: {e}"))?;
 
     check_api_error(&body).map_err(|(c, m)| format!("Last.fm error {c}: {m}"))?;
 
@@ -175,6 +174,7 @@ pub struct LastfmSession {
 /// a failure), and `Err` for a real problem (expired token, bad key, network).
 /// The frontend polls this so connecting needs no manual confirmation step.
 async fn get_session(
+    app: &AppHandle,
     client: &reqwest::Client,
     token: &str,
 ) -> Result<Option<LastfmSession>, String> {
@@ -184,15 +184,14 @@ async fn get_session(
     params.insert("token".into(), token.into());
     let params = finalize(params);
 
-    let body = client
+    let resp = client
         .get(API_ROOT)
         .query(&params)
         .send()
         .await
-        .map_err(|e| format!("network error: {e}"))?
-        .text()
-        .await
-        .map_err(|e| format!("read error: {e}"))?;
+        .map_err(|e| format!("network error: {e}"))?;
+    crate::diagnostics::note(app, "network", format!("lastfm auth.getSession {}", resp.status()));
+    let body = resp.text().await.map_err(|e| format!("read error: {e}"))?;
 
     match check_api_error(&body) {
         // 14 = token not yet authorized by the user: keep polling, not an error.
@@ -221,6 +220,7 @@ async fn get_session(
 }
 
 /// Outcome of a POST to Last.fm, used to decide the offline queue's fate.
+#[derive(Debug)]
 enum SendOutcome {
     Sent,
     /// Transport failure or a transient server error: keep for retry.
@@ -337,7 +337,9 @@ async fn flush_queue(app: &AppHandle, client: &reqwest::Client, lock: &Mutex<()>
         // Last.fm caps a scrobble batch at 50.
         for chunk in items.chunks(50) {
             let params = scrobble_batch_params(chunk, &sk);
-            match post_signed(client, params).await {
+            let outcome = post_signed(client, params).await;
+            crate::diagnostics::note(app, "network", format!("lastfm flush track.scrobble {outcome:?}"));
+            match outcome {
                 SendOutcome::Sent => {}
                 SendOutcome::Retry => remaining.extend_from_slice(chunk),
                 SendOutcome::Drop(msg) => {
@@ -361,12 +363,12 @@ pub fn lastfm_is_configured() -> bool {
 /// Step 1 of connecting: fetch a request token and hand back the browser URL
 /// the user must open to approve it.
 #[tauri::command]
-pub async fn lastfm_begin_auth() -> Result<BeginAuth, String> {
+pub async fn lastfm_begin_auth(app: AppHandle) -> Result<BeginAuth, String> {
     if API_KEY.is_empty() || API_SECRET.is_empty() {
         return Err("Last.fm API credentials are not configured in this build.".into());
     }
     let client = reqwest::Client::new();
-    let token = get_token(&client).await?;
+    let token = get_token(&app, &client).await?;
     let auth_url = format!(
         "https://www.last.fm/api/auth/?api_key={}&token={}",
         API_KEY, token
@@ -378,9 +380,9 @@ pub async fn lastfm_begin_auth() -> Result<BeginAuth, String> {
 /// once the user has approved the token in their browser, or `None` while it is
 /// still pending.
 #[tauri::command]
-pub async fn lastfm_poll_session(token: String) -> Result<Option<LastfmSession>, String> {
+pub async fn lastfm_poll_session(app: AppHandle, token: String) -> Result<Option<LastfmSession>, String> {
     let client = reqwest::Client::new();
-    get_session(&client, &token).await
+    get_session(&app, &client, &token).await
 }
 
 /// Public profile info for a Last.fm user, used to show an avatar + name in
@@ -396,7 +398,7 @@ pub struct LastfmUserInfo {
 }
 
 #[tauri::command]
-pub async fn lastfm_user_info(user: String) -> Result<LastfmUserInfo, String> {
+pub async fn lastfm_user_info(app: AppHandle, user: String) -> Result<LastfmUserInfo, String> {
     if API_KEY.is_empty() {
         return Err("Last.fm API credentials are not configured in this build.".into());
     }
@@ -407,15 +409,14 @@ pub async fn lastfm_user_info(user: String) -> Result<LastfmUserInfo, String> {
     params.insert("user".to_string(), user);
     params.insert("format".to_string(), "json".to_string());
 
-    let body = client
+    let resp = client
         .get(API_ROOT)
         .query(&params)
         .send()
         .await
-        .map_err(|e| format!("network error: {e}"))?
-        .text()
-        .await
-        .map_err(|e| format!("read error: {e}"))?;
+        .map_err(|e| format!("network error: {e}"))?;
+    crate::diagnostics::note(&app, "network", format!("lastfm user.getInfo {}", resp.status()));
+    let body = resp.text().await.map_err(|e| format!("read error: {e}"))?;
 
     check_api_error(&body).map_err(|(c, m)| format!("Last.fm error {c}: {m}"))?;
 
@@ -462,6 +463,7 @@ pub async fn lastfm_user_info(user: String) -> Result<LastfmUserInfo, String> {
 /// ephemeral (Last.fm expires it on its own), so a failure is never queued.
 #[tauri::command]
 pub async fn lastfm_update_now_playing(
+    app: AppHandle,
     artist: String,
     track: String,
     album: String,
@@ -484,8 +486,8 @@ pub async fn lastfm_update_now_playing(
     if let Some(d) = duration {
         params.insert("duration".into(), d.to_string());
     }
-    // Best-effort; the classification doesn't matter for now-playing.
-    let _ = post_signed(&client, params).await;
+    let outcome = post_signed(&client, params).await;
+    crate::diagnostics::note(&app, "network", format!("lastfm track.updateNowPlaying {outcome:?}"));
     Ok(())
 }
 
@@ -517,7 +519,9 @@ pub async fn lastfm_scrobble(
     };
 
     let params = scrobble_batch_params(std::slice::from_ref(&scrobble), &session_key);
-    match post_signed(&client, params).await {
+    let outcome = post_signed(&client, params).await;
+    crate::diagnostics::note(&app, "network", format!("lastfm track.scrobble {outcome:?}"));
+    match outcome {
         SendOutcome::Sent => {
             // Sent live, so a good moment to drain any backlog from an earlier
             // offline stretch.
@@ -543,6 +547,7 @@ pub async fn lastfm_scrobble(
 /// state isn't time-critical and isn't queued for retry (unlike scrobbles).
 #[tauri::command]
 pub async fn lastfm_love(
+    app: AppHandle,
     artist: String,
     track: String,
     loved: bool,
@@ -552,16 +557,15 @@ pub async fn lastfm_love(
         return Ok(());
     }
     let client = reqwest::Client::new();
+    let method = if loved { "track.love" } else { "track.unlove" };
     let mut params = BTreeMap::new();
-    params.insert(
-        "method".into(),
-        if loved { "track.love" } else { "track.unlove" }.into(),
-    );
+    params.insert("method".into(), method.into());
     params.insert("api_key".into(), API_KEY.into());
     params.insert("sk".into(), session_key);
     params.insert("artist".into(), artist);
     params.insert("track".into(), track);
-    let _ = post_signed(&client, params).await;
+    let outcome = post_signed(&client, params).await;
+    crate::diagnostics::note(&app, "network", format!("lastfm {method} {outcome:?}"));
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command as TokioCommand;
 use tokio::sync::{Mutex, Notify};
 
@@ -25,6 +25,7 @@ use tower_http::cors::CorsLayer;
 use tower_http::services::ServeFile;
 
 mod appid;
+mod diagnostics;
 mod discord;
 mod lastfm;
 mod media;
@@ -577,21 +578,21 @@ fn generate_account_id() -> String {
 /// common way a signed-in user is shown a sign-in button.
 async fn read_cookies_plain(app: &tauri::AppHandle) -> Option<String> {
     let path = active_cookies_path(app).await?;
-    read_jar_at(&path).await
+    read_jar_at(app, &path).await
 }
 
 /// Decrypt one account's jar off disk. Split out of
 /// `read_cookies_plain` so a refresh can compare against the specific
 /// account it is refreshing rather than whichever one is active.
-async fn read_jar_at(path: &std::path::Path) -> Option<String> {
+async fn read_jar_at(app: &tauri::AppHandle, path: &std::path::Path) -> Option<String> {
     let encrypted = match tokio::fs::read(path).await {
         Ok(b) => b,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            eprintln!("[auth] no cookie jar at {}", path.display());
+            diagnostics::note(app, "auth", format!("no cookie jar at {}", path.display()));
             return None;
         }
         Err(e) => {
-            eprintln!("[auth] read cookie jar failed: {e}");
+            diagnostics::note(app, "auth", format!("read cookie jar failed: {e}"));
             return None;
         }
     };
@@ -599,18 +600,18 @@ async fn read_jar_at(path: &std::path::Path) -> Option<String> {
     let plain = match tokio::task::spawn_blocking(move || secure_store::decrypt(&encrypted)).await {
         Ok(Ok(p)) => p,
         Ok(Err(e)) => {
-            eprintln!("[auth] decrypt cookie jar failed ({len} bytes): {e}");
+            diagnostics::note(app, "auth", format!("decrypt cookie jar failed ({len} bytes): {e}"));
             return None;
         }
         Err(e) => {
-            eprintln!("[auth] decrypt join failed: {e}");
+            diagnostics::note(app, "auth", format!("decrypt join failed: {e}"));
             return None;
         }
     };
     match String::from_utf8(plain) {
         Ok(s) => Some(s),
         Err(e) => {
-            eprintln!("[auth] cookie jar is not valid UTF-8: {e}");
+            diagnostics::note(app, "auth", format!("cookie jar is not valid UTF-8: {e}"));
             None
         }
     }
@@ -1067,7 +1068,7 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
     let account_id = generate_account_id();
     let webview_data = account_webview_dir(&app, &account_id);
     if let Err(e) = tokio::fs::create_dir_all(&webview_data).await {
-        eprintln!("[login] mkdir webview-data: {e}");
+        diagnostics::note(&app, "login", format!("mkdir webview-data: {e}"));
     }
     // Wiped wholesale on cancel/error (profile + any partial jar); kept
     // on success.
@@ -1107,10 +1108,13 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
         // Ticks spent waiting for the handshake to finish after auth
         // cookies first appear (see below).
         let mut full_set_grace: u8 = 0;
+        let mut tick: u32 = 0;
         loop {
             tokio::time::sleep(Duration::from_millis(1500)).await;
+            tick += 1;
 
             let Some(win) = app_poll.get_webview_window("login") else {
+                diagnostics::note(&app_poll, "login", "window closed before auth completed");
                 let _ = app_poll.emit("login-cancelled", ());
                 let _ = tokio::fs::remove_dir_all(&cleanup_dir).await;
                 return;
@@ -1119,7 +1123,7 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
             let cookies = match win.cookies() {
                 Ok(c) => c,
                 Err(e) => {
-                    eprintln!("[login] cookies error: {e}");
+                    diagnostics::note(&app_poll, "login", format!("cookies error: {e}"));
                     continue;
                 }
             };
@@ -1131,6 +1135,15 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
                         .map(|d| d.trim_start_matches('.').ends_with("youtube.com"))
                         .unwrap_or(false)
             });
+            diagnostics::note(
+                &app_poll,
+                "login",
+                format!(
+                    "tick={tick} cookies={} has_yt_auth={has_yt_auth} nudged_to_yt={nudged_to_yt} url={}",
+                    cookies.len(),
+                    win.url().map(|u| u.to_string()).unwrap_or_default(),
+                ),
+            );
 
             if !has_yt_auth {
                 // YT cookies aren't set yet. Two ways to land here:
@@ -1157,12 +1170,12 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
                     if has_google_auth {
                         if let Ok(url) = "https://music.youtube.com/".parse::<tauri::Url>() {
                             match win.navigate(url) {
-                                Ok(()) => eprintln!(
-                                    "[login] google-auth detected without YT cookies; redirected webview to music.youtube.com"
+                                Ok(()) => diagnostics::note(
+                                    &app_poll,
+                                    "login",
+                                    "google-auth detected without YT cookies, redirected webview to music.youtube.com",
                                 ),
-                                Err(e) => eprintln!(
-                                    "[login] failed to redirect to YT: {e}"
-                                ),
+                                Err(e) => diagnostics::note(&app_poll, "login", format!("failed to redirect to YT: {e}")),
                             }
                         }
                         nudged_to_yt = true;
@@ -1200,20 +1213,20 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
                 match tokio::task::spawn_blocking(move || secure_store::encrypt(&plain)).await {
                     Ok(Ok(e)) => e,
                     Ok(Err(e)) => {
-                        eprintln!("[login] encrypt cookies: {e}");
+                        diagnostics::note(&app_poll, "login", format!("encrypt cookies: {e}"));
                         let _ = win.close();
                         let _ = tokio::fs::remove_dir_all(&cleanup_dir).await;
                         return;
                     }
                     Err(e) => {
-                        eprintln!("[login] encrypt join: {e}");
+                        diagnostics::note(&app_poll, "login", format!("encrypt join: {e}"));
                         let _ = win.close();
                         let _ = tokio::fs::remove_dir_all(&cleanup_dir).await;
                         return;
                     }
                 };
             if let Err(e) = write_atomic(&cookies_path, &encrypted).await {
-                eprintln!("[login] write account cookies: {e}");
+                diagnostics::note(&app_poll, "login", format!("write account cookies: {e}"));
                 let _ = win.close();
                 let _ = tokio::fs::remove_dir_all(&cleanup_dir).await;
                 return;
@@ -1232,7 +1245,7 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
                 // visible to the user as "account didn't appear in
                 // list". Surface it through the cancel event so the
                 // frontend at least flips out of the spinning state.
-                eprintln!("[login] write index: {e}");
+                diagnostics::note(&app_poll, "login", format!("write index: {e}"));
                 let _ = app_poll.emit("login-cancelled", ());
                 let _ = tokio::fs::remove_dir_all(
                     &account_cookies_path(&app_poll, &new_id)
@@ -1252,6 +1265,7 @@ async fn start_login(app: tauri::AppHandle) -> Result<(), String> {
             // dedup happens (by identity, email or avatar) and where
             // `accounts-changed` fires, so we never run the full reset
             // twice for one login flow.
+            diagnostics::note(&app_poll, "login", format!("success, account={new_id}"));
             let _ = app_poll.emit("login-success", &new_id);
             let _ = win.close();
             // Keep the WebView profile: it's the live session the periodic
@@ -1357,7 +1371,7 @@ async fn refresh_account_cookies(app: &tauri::AppHandle, id: &str) -> Result<(),
     // store the keeper has actually reloaded into.
     let loads_before = KEEPER_PAGE_LOADS.load(Ordering::Relaxed);
     let (win, created) = ensure_session_keeper(app, id).await?;
-    eprintln!("[refresh] start id={id} keeper_created={created}");
+    diagnostics::note(app, "auth", format!("refresh start id={id} keeper_created={created}"));
     // A reused keeper is reloaded to force fresh authenticated traffic; a
     // just-created one is already loading the URL from the builder.
     if !created {
@@ -1419,9 +1433,12 @@ async fn refresh_account_cookies(app: &tauri::AppHandle, id: &str) -> Result<(),
     let Some(plain) = captured else {
         return Err("no auth cookies after reload (profile logged out?)".into());
     };
-    eprintln!(
-        "[refresh] captured at tick={captured_at} cookies={captured_count} \
-         has_login_info={captured_login_info} page_load_confirmed={saw_page_load}"
+    diagnostics::note(
+        app,
+        "auth",
+        format!(
+            "refresh captured at tick={captured_at} cookies={captured_count} has_login_info={captured_login_info} page_load_confirmed={saw_page_load}"
+        ),
     );
 
     // The keeper's snapshot replaces the jar wholesale, which throws away
@@ -1431,17 +1448,17 @@ async fn refresh_account_cookies(app: &tauri::AppHandle, id: &str) -> Result<(),
     // the right call and the semantics stay as they were, but the diff
     // has never been visible. Log it: if the keeper ever starts REGRESSING
     // values the replay path already learned, this is what will say so.
-    if let Some(existing) = read_jar_at(&account_cookies_path(app, id)).await {
+    if let Some(existing) = read_jar_at(app, &account_cookies_path(app, id)).await {
         let snapshot = String::from_utf8_lossy(&plain).into_owned();
         let before = jar_cookie_keys(&existing);
         let after = jar_cookie_keys(&snapshot);
         let dropped: Vec<&String> = before.difference(&after).collect();
         if !dropped.is_empty() {
-            eprintln!("[refresh] snapshot drops cookie(s) the jar held: {dropped:?}");
+            diagnostics::note(app, "auth", format!("refresh snapshot drops cookie(s) the jar held: {dropped:?}"));
         }
         let changed = changed_cookie_names(&existing, &snapshot);
         if !changed.is_empty() {
-            eprintln!("[refresh] snapshot rotates {changed:?}");
+            diagnostics::note(app, "auth", format!("refresh snapshot rotates {changed:?}"));
         }
     }
 
@@ -1553,9 +1570,10 @@ async fn run_refresh_loop(app: tauri::AppHandle) {
                 None => next_due = now_ts() + REFRESH_INTERVAL_SECS,
                 Some(active) if !account_webview_dir(&app, &active).exists() => {
                     if warned_profileless.as_deref() != Some(active.as_str()) {
-                        eprintln!(
-                            "[refresh] {active} has no persisted webview profile; its snapshot \
-                             cannot be renewed until the user signs in again"
+                        diagnostics::note(
+                            &app,
+                            "auth",
+                            format!("{active} has no persisted webview profile, snapshot cannot be renewed until the user signs in again"),
                         );
                         warned_profileless = Some(active.clone());
                     }
@@ -1568,13 +1586,13 @@ async fn run_refresh_loop(app: tauri::AppHandle) {
                     // cycle before.
                     if !power::wait_for_network(Duration::from_secs(60)).await {
                         if !warned_offline {
-                            eprintln!("[refresh] no internet; deferring until it comes back");
+                            diagnostics::note(&app, "auth", "refresh: no internet, deferring until it comes back");
                             warned_offline = true;
                         }
                         next_due = now_ts() + 30;
                     } else {
                         if warned_offline {
-                            eprintln!("[refresh] internet is back");
+                            diagnostics::note(&app, "auth", "refresh: internet is back");
                             warned_offline = false;
                         }
                         let previous = read_last_refresh(&app, &active).await;
@@ -1582,34 +1600,36 @@ async fn run_refresh_loop(app: tauri::AppHandle) {
                             Ok(()) => {
                                 let now = now_ts();
                                 match previous {
-                                    Some(t) => eprintln!(
-                                        "[refresh] renewed snapshot for {active} \
-                                         (previous succeeded {}s ago)",
-                                        now - t
+                                    Some(t) => diagnostics::note(
+                                        &app,
+                                        "auth",
+                                        format!("renewed snapshot for {active} (previous succeeded {}s ago)", now - t),
                                     ),
-                                    None => eprintln!("[refresh] renewed snapshot for {active}"),
+                                    None => diagnostics::note(&app, "auth", format!("renewed snapshot for {active}")),
                                 }
                                 write_last_refresh(&app, &active, now).await;
                                 failures = 0;
                                 next_due = now + REFRESH_INTERVAL_SECS;
                             }
                             Err(e) => {
-                                eprintln!("[refresh] {active}: {e}");
+                                diagnostics::note(&app, "auth", format!("refresh {active}: {e}"));
                                 // Separate "the keeper misbehaved" from
                                 // "the session is genuinely gone". Only
                                 // on the first failure, so a permanently
                                 // dead profile doesn't probe on a loop.
                                 if failures == 0 {
                                     match probe_session_alive(&app).await {
-                                        Ok(true) => eprintln!(
-                                            "[refresh] the jar still authenticates, so the \
-                                             keeper is what failed"
+                                        Ok(true) => diagnostics::note(
+                                            &app,
+                                            "auth",
+                                            "the jar still authenticates, so the keeper is what failed",
                                         ),
-                                        Ok(false) => eprintln!(
-                                            "[refresh] the jar no longer authenticates; this \
-                                             account needs a re-login"
+                                        Ok(false) => diagnostics::note(
+                                            &app,
+                                            "auth",
+                                            "the jar no longer authenticates, this account needs a re-login",
                                         ),
-                                        Err(e) => eprintln!("[refresh] liveness probe failed: {e}"),
+                                        Err(e) => diagnostics::note(&app, "auth", format!("liveness probe failed: {e}")),
                                     }
                                 }
                                 failures += 1;
@@ -2306,16 +2326,19 @@ async fn merge_response_cookies(
     // user out. If the session really is gone the keeper refresh fails
     // and leaves the jar alone; if it is fine, the snapshot is renewed.
     if !merged.blocked_deletions.is_empty() {
-        eprintln!(
-            "[auth] refused server expiry of identity cookie(s) {:?} from {host}; \
-             re-checking the session against the keeper",
-            merged.blocked_deletions
+        diagnostics::note(
+            &app,
+            "auth",
+            format!(
+                "refused server expiry of identity cookie(s) {:?} from {host}, re-checking the session against the keeper",
+                merged.blocked_deletions
+            ),
         );
         let app_probe = app.clone();
         tauri::async_runtime::spawn(async move {
             if let Some(active) = read_index(&app_probe).await.active {
                 if let Err(e) = refresh_account_cookies(&app_probe, &active).await {
-                    eprintln!("[auth] post-expiry keeper re-check failed: {e}");
+                    diagnostics::note(&app_probe, "auth", format!("post-expiry keeper re-check failed: {e}"));
                 }
             }
         });
@@ -2325,7 +2348,7 @@ async fn merge_response_cookies(
     // is correct browser behavior. It has never been logged, so we have
     // no idea how often it fires in the field. Report it.
     for gone in jar_cookie_keys(&jar).difference(&jar_cookie_keys(&merged.jar)) {
-        eprintln!("[auth] server expired cookie {gone} (response host {host})");
+        diagnostics::note(&app, "auth", format!("server expired cookie {gone} (response host {host})"));
     }
 
     if !merged.needs_write {
@@ -2343,7 +2366,7 @@ async fn merge_response_cookies(
         .await
         .map_err(|e| format!("write jar: {e}"))?;
     if value_changed {
-        eprintln!("[auth] echoed rotated session cookie(s) into the active jar");
+        diagnostics::note(&app, "auth", "echoed rotated session cookie(s) into the active jar");
     }
     Ok(value_changed)
 }
@@ -2761,6 +2784,7 @@ struct StreamServer {
     /// `ytdlp::program` so a mid-session download takes effect
     /// immediately.
     ytdlp_bin: PathBuf,
+    app: tauri::AppHandle,
 }
 
 /// Read the `ephemeral` query flag from a stream/prefetch request.
@@ -3073,12 +3097,15 @@ fn spawn_downloader(
     state: Arc<DownloadState>,
 ) {
     let downloads = srv.downloads.clone();
+    let app = srv.app.clone();
     tokio::spawn(async move {
         let url = format!("https://www.youtube.com/watch?v={video_id}");
         let part_path = target_dir.join(format!("{video_id}.part"));
         let final_path = target_dir.join(format!("{video_id}.webm"));
         let _ = tokio::fs::create_dir_all(&target_dir).await;
         let _ = tokio::fs::remove_file(&part_path).await; // clean stale
+
+        diagnostics::note(&app, "stream", format!("{video_id}: spawning yt-dlp"));
 
         let mut cmd = TokioCommand::new(ytdlp::program(&srv.ytdlp_bin));
         cmd.args([
@@ -3111,16 +3138,28 @@ fn spawn_downloader(
         // (see resolve_stream_ytdlp for rationale).
         #[cfg(windows)]
         cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
-        let mut child = match cmd.stdout(Stdio::piped()).stderr(Stdio::inherit()).spawn() {
+        let mut child = match cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
             Ok(c) => c,
             Err(e) => {
-                eprintln!("[stream] spawn {video_id}: {e}");
+                diagnostics::note(&app, "stream", format!("spawn {video_id}: {e}"));
                 state.complete.store(true, Ordering::Release);
                 state.notify.notify_waiters();
                 downloads.lock().await.remove(&map_key);
                 return;
             }
         };
+
+        let stderr = child.stderr.take().unwrap();
+        let stderr_app = app.clone();
+        let stderr_id = video_id.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if !line.trim().is_empty() {
+                    diagnostics::note(&stderr_app, "ytdlp", format!("{stderr_id}: {line}"));
+                }
+            }
+        });
 
         let mut stdout = child.stdout.take().unwrap();
         let mut file = tokio::fs::File::create(&part_path).await.ok();
@@ -3134,7 +3173,7 @@ fn spawn_downloader(
         loop {
             match tokio::time::timeout(READ_TIMEOUT, stdout.read(&mut buf)).await {
                 Err(_) => {
-                    eprintln!("[stream] read timeout for {video_id}; killing yt-dlp");
+                    diagnostics::note(&app, "stream", format!("read timeout for {video_id}, killing yt-dlp"));
                     let _ = child.start_kill();
                     ok = false;
                     break;
@@ -3144,7 +3183,7 @@ fn spawn_downloader(
                     let chunk = &buf[..n];
                     if let Some(ref mut f) = file {
                         if let Err(e) = f.write_all(chunk).await {
-                            eprintln!("[stream] write .part: {e}");
+                            diagnostics::note(&app, "stream", format!("write .part: {e}"));
                             file = None;
                             // A truncated prefix must NOT be renamed to .webm
                             // and cached — mark the whole download failed.
@@ -3154,7 +3193,7 @@ fn spawn_downloader(
                     state.notify.notify_waiters();
                 }
                 Ok(Err(e)) => {
-                    eprintln!("[stream] read stdout: {e}");
+                    diagnostics::note(&app, "stream", format!("read stdout: {e}"));
                     ok = false;
                     break;
                 }
@@ -3184,18 +3223,22 @@ fn spawn_downloader(
             .unwrap_or(0);
         if success && part_size >= MIN_AUDIO_BYTES {
             if let Err(e) = tokio::fs::rename(&part_path, &final_path).await {
-                eprintln!("[stream] rename: {e}");
+                diagnostics::note(&app, "stream", format!("rename: {e}"));
                 let _ = tokio::fs::remove_file(&part_path).await;
             } else {
-                eprintln!("[stream] cached {video_id} ({part_size} bytes)");
+                diagnostics::note(&app, "stream", format!("cached {video_id} ({part_size} bytes)"));
             }
         } else {
             if success {
-                eprintln!(
-                    "[stream] download too small for {video_id}: {part_size} bytes (min {MIN_AUDIO_BYTES})"
+                diagnostics::note(
+                    &app,
+                    "stream",
+                    format!(
+                        "download too small for {video_id}: {part_size} bytes (min {MIN_AUDIO_BYTES})"
+                    ),
                 );
             } else {
-                eprintln!("[stream] download failed {video_id}");
+                diagnostics::note(&app, "stream", format!("download failed {video_id}"));
             }
             let _ = tokio::fs::remove_file(&part_path).await;
         }
@@ -3291,9 +3334,13 @@ async fn stream_handler(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
         .to_string();
-    eprintln!(
-        "[stream] GET /stream/{video_id} range={range_hdr:?} cached={} ephemeral={ephemeral}",
-        final_path.exists()
+    diagnostics::note(
+        &srv.app,
+        "stream",
+        format!(
+            "GET /stream/{video_id} range={range_hdr:?} cached={} ephemeral={ephemeral}",
+            final_path.exists()
+        ),
     );
 
     if !final_path.exists() {
@@ -3325,7 +3372,7 @@ async fn stream_handler(
         let deadline = tokio::time::Instant::now() + Duration::from_secs(120);
         while !state.complete.load(Ordering::Acquire) {
             if tokio::time::Instant::now() >= deadline {
-                eprintln!("[stream] {video_id}: TIMEOUT after 120s");
+                diagnostics::note(&srv.app, "stream", format!("{video_id}: TIMEOUT after 120s"));
                 return (StatusCode::GATEWAY_TIMEOUT, "download timeout").into_response();
             }
             let notified = state.notify.notified();
@@ -3334,15 +3381,20 @@ async fn stream_handler(
         }
 
         if !final_path.exists() {
-            eprintln!(
-                "[stream] {video_id}: BAD_GATEWAY — complete but no .webm (elapsed {:.2}s)",
-                t0.elapsed().as_secs_f32()
+            diagnostics::note(
+                &srv.app,
+                "stream",
+                format!(
+                    "{video_id}: BAD_GATEWAY, complete but no .webm (elapsed {:.2}s)",
+                    t0.elapsed().as_secs_f32()
+                ),
             );
             return (StatusCode::BAD_GATEWAY, "download failed").into_response();
         }
-        eprintln!(
-            "[stream] {video_id}: download finished in {:.2}s",
-            t0.elapsed().as_secs_f32()
+        diagnostics::note(
+            &srv.app,
+            "stream",
+            format!("{video_id}: download finished in {:.2}s", t0.elapsed().as_secs_f32()),
         );
     }
 
@@ -3365,16 +3417,20 @@ async fn stream_handler(
             axum::http::HeaderValue::from_static(sniffed_ct),
         );
     }
-    eprintln!(
-        "[stream] {video_id}: responding {} ({:.2}s total) ct={:?} len={:?}",
-        resp.status(),
-        t0.elapsed().as_secs_f32(),
-        resp.headers()
-            .get(axum::http::header::CONTENT_TYPE)
-            .and_then(|v| v.to_str().ok()),
-        resp.headers()
-            .get(axum::http::header::CONTENT_LENGTH)
-            .and_then(|v| v.to_str().ok()),
+    diagnostics::note(
+        &srv.app,
+        "stream",
+        format!(
+            "{video_id}: responding {} ({:.2}s total) ct={:?} len={:?}",
+            resp.status(),
+            t0.elapsed().as_secs_f32(),
+            resp.headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            resp.headers()
+                .get(axum::http::header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok()),
+        ),
     );
     resp
 }
@@ -3490,15 +3546,16 @@ async fn start_stream_server(
     ephemeral_dir: PathBuf,
     cover_dir: PathBuf,
     ytdlp_bin: PathBuf,
+    app: tauri::AppHandle,
 ) {
     if let Err(e) = tokio::fs::create_dir_all(&cache_dir).await {
-        eprintln!("[stream-server] mkdir {cache_dir:?}: {e}");
+        diagnostics::note(&app, "stream-server", format!("mkdir {cache_dir:?}: {e}"));
     }
     if let Err(e) = tokio::fs::create_dir_all(&ephemeral_dir).await {
-        eprintln!("[stream-server] mkdir {ephemeral_dir:?}: {e}");
+        diagnostics::note(&app, "stream-server", format!("mkdir {ephemeral_dir:?}: {e}"));
     }
     if let Err(e) = tokio::fs::create_dir_all(&cover_dir).await {
-        eprintln!("[stream-server] mkdir {cover_dir:?}: {e}");
+        diagnostics::note(&app, "stream-server", format!("mkdir {cover_dir:?}: {e}"));
     }
 
     // Wipe whatever a previous (anonymous / Free) session left behind.
@@ -3516,16 +3573,18 @@ async fn start_stream_server(
             }
         }
         if wiped > 0 {
-            eprintln!("[stream-server] wiped {wiped} bytes from ephemeral dir");
+            diagnostics::note(&app, "stream-server", format!("wiped {wiped} bytes from ephemeral dir"));
         }
     }
 
+    let log_handle = app.clone();
     let server = StreamServer {
         cache_dir,
         ephemeral_dir,
         cover_dir,
         downloads: Arc::new(Mutex::new(HashMap::new())),
         ytdlp_bin,
+        app,
     };
 
     // Per-launch token as an unguessable path prefix. Baked into the base
@@ -3540,7 +3599,7 @@ async fn start_stream_server(
         .route("/prefetch/:video_id", get(prefetch_handler))
         .route("/cover/:filename", get(cover_serve_handler))
         .with_state(server);
-    let app = Router::new()
+    let router = Router::new()
         .nest(&format!("/{token}"), routes)
         .layer(CorsLayer::permissive());
 
@@ -3548,22 +3607,22 @@ async fn start_stream_server(
     let listener = match tokio::net::TcpListener::bind(addr).await {
         Ok(l) => l,
         Err(e) => {
-            eprintln!("[stream-server] bind failed: {e}");
+            diagnostics::note(&log_handle, "stream-server", format!("bind failed: {e}"));
             return;
         }
     };
     let port = match listener.local_addr() {
         Ok(a) => a.port(),
         Err(e) => {
-            eprintln!("[stream-server] local_addr failed: {e}");
+            diagnostics::note(&log_handle, "stream-server", format!("local_addr failed: {e}"));
             return;
         }
     };
     *port_state.lock().await = Some(port);
-    eprintln!("[stream-server] listening on 127.0.0.1:{port}");
+    diagnostics::note(&log_handle, "stream-server", format!("listening on 127.0.0.1:{port}"));
 
-    if let Err(e) = axum::serve(listener, app).await {
-        eprintln!("[stream-server] serve error: {e}");
+    if let Err(e) = axum::serve(listener, router).await {
+        diagnostics::note(&log_handle, "stream-server", format!("serve error: {e}"));
     }
 }
 
@@ -3701,6 +3760,7 @@ pub fn run() {
             None,
         ))
         .manage(state)
+        .manage(diagnostics::DiagState::default())
         .manage(CloseBehavior::default())
         .manage(JarWriteLock::default())
         .manage(RefreshGuard::default())
@@ -3742,6 +3802,10 @@ pub fn run() {
             focus_main_window,
             open_player_window,
             close_player_window,
+            diagnostics::diag_backlog,
+            diagnostics::open_diag_window,
+            diagnostics::close_diag_window,
+            diagnostics::diag_log,
             media::media_update,
             media::media_clear,
             discord::discord_update,
@@ -3787,10 +3851,14 @@ pub fn run() {
             }
         })
         .setup(move |app| {
-            eprintln!(
-                "[boot] YTubic {} starting (debug={})",
-                app.package_info().version,
-                cfg!(debug_assertions)
+            diagnostics::note(
+                app.handle(),
+                "boot",
+                format!(
+                    "YTubic {} starting (debug={})",
+                    app.package_info().version,
+                    cfg!(debug_assertions)
+                ),
             );
             let port = port_handle.clone();
             let token = token_handle.clone();
@@ -3810,10 +3878,13 @@ pub fn run() {
             let ephemeral_dir = cache_root.join("stream-ephemeral");
             let cover_dir = cache_root.join("covers");
             let handle = app.handle().clone();
-            eprintln!("[stream-server] cache dir: {cache_dir:?}");
-            eprintln!("[stream-server] ephemeral dir: {ephemeral_dir:?}");
-            eprintln!("[stream-server] cover dir: {cover_dir:?}");
+            diagnostics::note(
+                &handle,
+                "stream-server",
+                format!("cache dir: {cache_dir:?}, ephemeral dir: {ephemeral_dir:?}, cover dir: {cover_dir:?}"),
+            );
             let ytdlp_bin = ytdlp::managed_path(&handle);
+            let server_handle = handle.clone();
             tauri::async_runtime::spawn(async move {
                 migrate_plaintext_cookies(&handle).await;
                 migrate_to_accounts_layout(&handle).await;
@@ -3821,7 +3892,15 @@ pub fn run() {
                 // email-based dedup before the UI reads the list.
                 dedup_accounts_by_identity(&handle).await;
                 cleanup_login_artifacts(&handle).await;
-                start_stream_server(port, token, cache_dir, ephemeral_dir, cover_dir, ytdlp_bin)
+                start_stream_server(
+                    port,
+                    token,
+                    cache_dir,
+                    ephemeral_dir,
+                    cover_dir,
+                    ytdlp_bin,
+                    server_handle,
+                )
                     .await;
             });
             // Subscribe to resume-from-sleep before the loop starts, so a

--- a/src-tauri/src/ytdlp.rs
+++ b/src-tauri/src/ytdlp.rs
@@ -87,8 +87,9 @@ pub async fn ensure(app: tauri::AppHandle) {
     let managed = managed_path(&app);
 
     if managed.exists() {
+        crate::diagnostics::note(&app, "ytdlp", format!("managed binary present at {managed:?}"));
         emit_state(&app, "ready", None);
-        maybe_self_update(&managed).await;
+        maybe_self_update(&managed, &app).await;
         return;
     }
 
@@ -97,19 +98,21 @@ pub async fn ensure(app: tauri::AppHandle) {
     // stops depending on the machine's PATH from the next launch on.
     let path_works = probe_path_install().await;
     if path_works {
+        crate::diagnostics::note(&app, "ytdlp", "no managed binary yet, PATH install works");
         emit_state(&app, "ready", None);
     } else {
+        crate::diagnostics::note(&app, "ytdlp", "no managed binary and no working PATH install, downloading");
         emit_state(&app, "downloading", None);
     }
 
     match download(&managed).await {
         Ok(()) => {
-            eprintln!("[ytdlp] downloaded managed binary to {managed:?}");
+            crate::diagnostics::note(&app, "ytdlp", format!("downloaded managed binary to {managed:?}"));
             touch_update_stamp(&managed);
             emit_state(&app, "ready", None);
         }
         Err(e) => {
-            eprintln!("[ytdlp] download failed: {e}");
+            crate::diagnostics::note(&app, "ytdlp", format!("download failed: {e}"));
             if !path_works {
                 emit_state(&app, "error", Some(e));
             }
@@ -231,7 +234,7 @@ fn update_stamp_age(managed: &Path) -> Option<Duration> {
 /// than `UPDATE_INTERVAL`. The official release binary replaces itself
 /// in place. The stamp is refreshed even on failure so a broken update
 /// path can't turn into a retry storm on every launch.
-async fn maybe_self_update(managed: &Path) {
+async fn maybe_self_update(managed: &Path, app: &tauri::AppHandle) {
     match update_stamp_age(managed) {
         Some(age) if age < UPDATE_INTERVAL => return,
         _ => {}
@@ -257,12 +260,12 @@ async fn maybe_self_update(managed: &Path) {
                     .rev()
                     .find(|l| !l.trim().is_empty())
                     .unwrap_or("");
-                eprintln!("[ytdlp] self-update ({}): {line}", out.status);
+                crate::diagnostics::note(app, "ytdlp", format!("self-update ({}): {line}", out.status));
             }
-            Err(e) => eprintln!("[ytdlp] self-update spawn failed: {e}"),
+            Err(e) => crate::diagnostics::note(app, "ytdlp", format!("self-update spawn failed: {e}")),
         }
     };
     if tokio::time::timeout(UPDATE_TIMEOUT, run).await.is_err() {
-        eprintln!("[ytdlp] self-update timed out");
+        crate::diagnostics::note(app, "ytdlp", "self-update timed out");
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,12 +11,19 @@ import {
 import { routeTree } from "@/routeTree.gen";
 import { isFloatingPlayerWindow } from "@/lib/floating-player";
 import FloatingPlayerApp from "@/components/layout/floating-player-app";
+import { isDiagnosticsWindow } from "@/lib/diagnostics";
+import DiagnosticsApp from "@/components/layout/diagnostics-app";
+import { diagLog } from "@/lib/diagnostics";
 
 const router = createRouter({
   routeTree,
   defaultPreload: "intent",
   defaultPreloadStaleTime: 0,
   context: { queryClient },
+});
+
+router.subscribe("onResolved", () => {
+  diagLog("ui", `navigate ${router.state.location.pathname}`);
 });
 
 declare module "@tanstack/react-router" {
@@ -30,6 +37,9 @@ export default function App() {
   // floating player skips routing/shell entirely.
   if (isFloatingPlayerWindow()) {
     return <FloatingPlayerApp />;
+  }
+  if (isDiagnosticsWindow()) {
+    return <DiagnosticsApp />;
   }
   return (
     <ThemeProvider

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -37,9 +37,11 @@ import { useLayoutStore } from "@/lib/store/layout";
 import { usePremiumStatusSync } from "@/lib/store/premium";
 import {
   useCloseBehaviorSync,
+  useDebugConsoleSync,
   useDiscordPresenceSync,
   useSettingsStore,
 } from "@/lib/store/settings";
+import { useInteractionLogger } from "@/lib/interaction-logger";
 import {
   useAccountMetaBackfill,
   useAccountsChangedListener,
@@ -101,6 +103,8 @@ export function AppShell({ children }: { children: ReactNode }) {
   useGlobalShortcuts();
   useCloseBehaviorSync();
   useDiscordPresenceSync();
+  useDebugConsoleSync();
+  useInteractionLogger();
   useCacheAutoClean();
   usePlaybackNotifications();
   useLastfmScrobbler();

--- a/src/components/layout/diagnostics-app.tsx
+++ b/src/components/layout/diagnostics-app.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { DiagLine } from "@/lib/diagnostics";
+import { cn } from "@/lib/utils";
+
+const TAG_COLORS: Record<string, string> = {
+  boot: "text-sky-400",
+  "stream-server": "text-sky-400",
+  stream: "text-amber-400",
+  ytdlp: "text-rose-400",
+};
+
+function tagColor(tag: string): string {
+  return TAG_COLORS[tag] ?? "text-emerald-400";
+}
+
+function mergeBacklog(backlog: DiagLine[], live: DiagLine[]): DiagLine[] {
+  const seen = new Set<string>();
+  const merged: DiagLine[] = [];
+  for (const l of [...backlog, ...live]) {
+    const key = `${l.at}|${l.tag}|${l.text}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(l);
+  }
+  merged.sort((a, b) => a.at - b.at);
+  return merged.slice(-4000);
+}
+
+function formatClock(atMs: number): string {
+  const d = new Date(atMs);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${d
+    .getMilliseconds()
+    .toString()
+    .padStart(3, "0")}`;
+}
+
+export default function DiagnosticsApp() {
+  const [lines, setLines] = useState<DiagLine[]>([]);
+  const [query, setQuery] = useState("");
+  const [pinnedToEnd, setPinnedToEnd] = useState(true);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void invoke<DiagLine[]>("diag_backlog").then((backlog) => {
+      if (!cancelled) setLines((prev) => mergeBacklog(backlog, prev));
+    });
+    const unlisten = listen<DiagLine>("diag-line", (event) => {
+      setLines((prev) => [...prev, event.payload].slice(-4000));
+    });
+    return () => {
+      cancelled = true;
+      void unlisten.then((un) => un());
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!pinnedToEnd) return;
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [lines, pinnedToEnd]);
+
+  const filtered = query.trim()
+    ? lines.filter(
+        (l) =>
+          l.text.toLowerCase().includes(query.toLowerCase()) ||
+          l.tag.toLowerCase().includes(query.toLowerCase()),
+      )
+    : lines;
+
+  return (
+    <div className="flex h-screen w-screen flex-col bg-neutral-950 text-neutral-200">
+      <div className="flex shrink-0 items-center gap-2 border-b border-neutral-800 px-3 py-2">
+        <span className="text-sm font-medium text-neutral-300">
+          YTubic diagnostics
+        </span>
+        <span className="text-xs text-neutral-500">
+          {filtered.length}/{lines.length} lines
+        </span>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="filter by text or tag"
+          className="ml-3 h-7 flex-1 rounded border border-neutral-700 bg-neutral-900 px-2 text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none"
+        />
+        <label className="flex items-center gap-1 text-xs text-neutral-400">
+          <input
+            type="checkbox"
+            checked={pinnedToEnd}
+            onChange={(e) => setPinnedToEnd(e.target.checked)}
+          />
+          follow
+        </label>
+        <button
+          type="button"
+          onClick={() => setLines([])}
+          className="h-7 rounded border border-neutral-700 px-2 text-xs text-neutral-300 hover:bg-neutral-800"
+        >
+          clear
+        </button>
+      </div>
+      <div
+        ref={scrollRef}
+        onScroll={(e) => {
+          const el = e.currentTarget;
+          const atEnd = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
+          setPinnedToEnd(atEnd);
+        }}
+        className="flex-1 overflow-y-auto px-3 py-2 font-mono text-xs leading-5"
+      >
+        {filtered.map((l, i) => (
+          <div key={i} className="flex gap-2 whitespace-pre-wrap break-all">
+            <span className="shrink-0 text-neutral-600">
+              {formatClock(l.at)}
+            </span>
+            <span className={cn("shrink-0", tagColor(l.tag))}>
+              [{l.tag}]
+            </span>
+            <span className="text-neutral-300">{l.text}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/report-issue-dialog.tsx
+++ b/src/components/layout/report-issue-dialog.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react";
+import { getVersion } from "@tauri-apps/api/app";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  frostedDialogOverlay,
+  frostedDialogPanel,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+const REPO_ISSUES_URL = "https://github.com/NUber-dev/YTubic/issues/new";
+
+export function ReportIssueDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+
+  useEffect(() => {
+    if (!open) {
+      setTitle("");
+      setBody("");
+    }
+  }, [open]);
+
+  const submit = async () => {
+    if (!body.trim()) return;
+    let version = "unknown";
+    try {
+      version = await getVersion();
+    } catch {}
+    const fullBody = [
+      body.trim(),
+      "",
+      "---",
+      `App version: ${version}`,
+      `OS: ${navigator.userAgent}`,
+    ].join("\n");
+    const params = new URLSearchParams({ body: fullBody });
+    if (title.trim()) params.set("title", title.trim());
+    try {
+      await openUrl(`${REPO_ISSUES_URL}?${params}`);
+      toast.success("Thanks! Finish submitting the issue in your browser.");
+      onOpenChange(false);
+    } catch (e) {
+      toast.error("Couldn't open the browser", { description: String(e) });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={frostedDialogPanel}
+        overlayClassName={frostedDialogOverlay}
+      >
+        <DialogHeader>
+          <DialogTitle>Report an issue</DialogTitle>
+          <DialogDescription>
+            Tell us what went wrong or what you'd like to see. Submitting opens
+            a prefilled GitHub issue in your browser with the app version and
+            OS attached automatically.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <Input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Short summary (optional)"
+          />
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="What happened? Steps to reproduce, expected vs actual…"
+            rows={6}
+            className="w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:bg-input/30"
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => void submit()} disabled={!body.trim()}>
+            Submit
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/layout/top-bar.tsx
+++ b/src/components/layout/top-bar.tsx
@@ -2,8 +2,6 @@ import { useEffect, useState } from "react";
 import { useRouter } from "@tanstack/react-router";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { invoke } from "@tauri-apps/api/core";
-import { getVersion } from "@tauri-apps/api/app";
-import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
@@ -23,7 +21,6 @@ import {
   PowerIcon,
 } from "lucide-react";
 import { useTheme } from "next-themes";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import {
@@ -38,22 +35,12 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  frostedDialogOverlay,
-  frostedDialogPanel,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import { useLayoutStore, type LayoutMode } from "@/lib/store/layout";
 import { IS_MAC } from "@/lib/platform";
 import { openSettings } from "@/lib/store/settings-dialog";
 import { checkForUpdates } from "@/lib/updater";
 import { AboutDialog } from "@/components/layout/about-dialog";
+import { ReportIssueDialog } from "@/components/layout/report-issue-dialog";
 
 // Caption-bar nav buttons get just an icon-color shift on hover —
 // the default ghost-button square highlight competes visually with
@@ -303,100 +290,6 @@ function ThemeSubMenu() {
         </DropdownMenuRadioGroup>
       </DropdownMenuSubContent>
     </DropdownMenuSub>
-  );
-}
-
-const REPO_ISSUES_URL = "https://github.com/NUber-dev/YTubic/issues/new";
-
-/**
- * Feedback form that hands off to GitHub: Submit opens a prefilled
- * new-issue page in the default browser with the app version and OS
- * appended, so reports arrive with the diagnostics we always ask for.
- * Voting/discussion happens on GitHub — no backend of our own.
- */
-function ReportIssueDialog({
-  open,
-  onOpenChange,
-}: {
-  open: boolean;
-  onOpenChange: (v: boolean) => void;
-}) {
-  const [title, setTitle] = useState("");
-  const [body, setBody] = useState("");
-
-  useEffect(() => {
-    if (!open) {
-      setTitle("");
-      setBody("");
-    }
-  }, [open]);
-
-  const submit = async () => {
-    if (!body.trim()) return;
-    let version = "unknown";
-    try {
-      version = await getVersion();
-    } catch {
-      /* non-Tauri context (plain vite dev) — keep "unknown" */
-    }
-    const fullBody = [
-      body.trim(),
-      "",
-      "---",
-      `App version: ${version}`,
-      `OS: ${navigator.userAgent}`,
-    ].join("\n");
-    const params = new URLSearchParams({ body: fullBody });
-    if (title.trim()) params.set("title", title.trim());
-    try {
-      await openUrl(`${REPO_ISSUES_URL}?${params}`);
-      toast.success("Thanks! Finish submitting the issue in your browser.");
-      onOpenChange(false);
-    } catch (e) {
-      toast.error("Couldn't open the browser", { description: String(e) });
-    }
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        className={frostedDialogPanel}
-        overlayClassName={frostedDialogOverlay}
-      >
-        <DialogHeader>
-          <DialogTitle>Report an issue</DialogTitle>
-          <DialogDescription>
-            Tell us what went wrong or what you'd like to see. Submitting opens
-            a prefilled GitHub issue in your browser — app version and OS are
-            attached automatically.
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="flex flex-col gap-3">
-          <Input
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="Short summary (optional)"
-          />
-          <textarea
-            value={body}
-            onChange={(e) => setBody(e.target.value)}
-            placeholder="What happened? Steps to reproduce, expected vs actual…"
-            rows={6}
-            className="w-full resize-none rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:bg-input/30"
-          />
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button onClick={() => void submit()} disabled={!body.trim()}>
-            Submit
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }
 

--- a/src/components/settings/help-tab.tsx
+++ b/src/components/settings/help-tab.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { BugIcon, DownloadIcon, InfoIcon, TerminalIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Group, SettingRow, TabPane } from "@/components/settings/primitives";
+import { useSettingsStore } from "@/lib/store/settings";
+import { checkForUpdates } from "@/lib/updater";
+import { AboutDialog } from "@/components/layout/about-dialog";
+import { ReportIssueDialog } from "@/components/layout/report-issue-dialog";
+
+export function HelpTab() {
+  const [reportOpen, setReportOpen] = useState(false);
+  const [aboutOpen, setAboutOpen] = useState(false);
+  const debugConsoleEnabled = useSettingsStore((s) => s.debugConsoleEnabled);
+  const setDebugConsoleEnabled = useSettingsStore(
+    (s) => s.setDebugConsoleEnabled,
+  );
+
+  return (
+    <TabPane tightTop>
+      <Group>
+        <SettingRow
+          icon={TerminalIcon}
+          title="Debug console"
+          description="Show a live log window of playback and streaming activity for bug reporting purposes."
+          control={
+            <Switch
+              checked={debugConsoleEnabled}
+              onCheckedChange={setDebugConsoleEnabled}
+              aria-label="Debug console"
+            />
+          }
+        />
+        <SettingRow
+          icon={DownloadIcon}
+          title="Check for updates"
+          description="See if a newer version of YTubic is available."
+          control={
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => void checkForUpdates({ silent: false })}
+            >
+              Check now
+            </Button>
+          }
+        />
+        <SettingRow
+          icon={BugIcon}
+          title="Report an issue"
+          description="Tell us what went wrong or what you'd like to see, via GitHub."
+          control={
+            <Button variant="outline" size="sm" onClick={() => setReportOpen(true)}>
+              Report
+            </Button>
+          }
+        />
+        <SettingRow
+          icon={InfoIcon}
+          title="About"
+          description="Version, credits, and links."
+          control={
+            <Button variant="outline" size="sm" onClick={() => setAboutOpen(true)}>
+              View
+            </Button>
+          }
+        />
+      </Group>
+      <ReportIssueDialog open={reportOpen} onOpenChange={setReportOpen} />
+      <AboutDialog open={aboutOpen} onOpenChange={setAboutOpen} />
+    </TabPane>
+  );
+}

--- a/src/components/settings/settings-dialog.tsx
+++ b/src/components/settings/settings-dialog.tsx
@@ -1,4 +1,5 @@
 import {
+  CircleHelpIcon,
   DatabaseIcon,
   PaletteIcon,
   PlugIcon,
@@ -19,6 +20,7 @@ import { GeneralTab } from "@/components/settings/general-tab";
 import { AppearanceTab } from "@/components/settings/appearance-tab";
 import { StorageTab } from "@/components/settings/storage-tab";
 import { IntegrationsTab } from "@/components/settings/integrations-tab";
+import { HelpTab } from "@/components/settings/help-tab";
 import {
   useSettingsDialog,
   type SettingsTab,
@@ -30,6 +32,7 @@ const TABS: { id: SettingsTab; label: string; icon: LucideIcon }[] = [
   { id: "appearance", label: "Appearance", icon: PaletteIcon },
   { id: "storage", label: "Storage", icon: DatabaseIcon },
   { id: "integrations", label: "Integrations", icon: PlugIcon },
+  { id: "help", label: "Help", icon: CircleHelpIcon },
 ];
 
 /**
@@ -129,6 +132,7 @@ export function SettingsDialog() {
             {tab === "appearance" && <AppearanceTab />}
             {tab === "storage" && <StorageTab />}
             {tab === "integrations" && <IntegrationsTab />}
+            {tab === "help" && <HelpTab />}
           </div>
         </div>
       </DialogContent>

--- a/src/lib/cover-art.ts
+++ b/src/lib/cover-art.ts
@@ -1,6 +1,7 @@
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { invoke } from "@tauri-apps/api/core";
 import { createStore, del, entries, get, set } from "idb-keyval";
+import { diagLog } from "@/lib/diagnostics";
 
 /**
  * iTunes Search API as a hi-res cover-art fallback.
@@ -177,10 +178,15 @@ export async function lookupITunesCover(
 
       const term = encodeURIComponent(`${artist} ${title}`);
       const url = `https://itunes.apple.com/search?term=${term}&entity=song&limit=1`;
+      const started = performance.now();
       const res = await tauriFetch(url, {
         method: "GET",
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
+      diagLog(
+        "network",
+        `itunes.apple.com GET ${res.status} ${Math.round(performance.now() - started)}ms`,
+      );
       if (!res.ok) {
         // Don't cache transient HTTP failures.
         return null;

--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -1,0 +1,18 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export const DIAG_QUERY_FLAG = "diagnostics";
+
+export function diagLog(tag: string, text: string): void {
+  void invoke("diag_log", { tag, text }).catch(() => {});
+}
+
+export function isDiagnosticsWindow(): boolean {
+  if (typeof window === "undefined") return false;
+  return new URLSearchParams(window.location.search).has(DIAG_QUERY_FLAG);
+}
+
+export type DiagLine = {
+  at: number;
+  tag: string;
+  text: string;
+};

--- a/src/lib/innertube/channels.ts
+++ b/src/lib/innertube/channels.ts
@@ -6,6 +6,7 @@ import {
   DESKTOP_UA,
   type YtNode,
 } from "./shared";
+import { diagLog } from "@/lib/diagnostics";
 
 /**
  * One selectable YouTube identity inside the signed-in Google account:
@@ -43,6 +44,7 @@ export function stripXssiPrefix(text: string): string {
 export async function fetchChannelList(): Promise<ChannelChoice[]> {
   const auth = await authHeaders();
   if (!auth.Cookie) return [];
+  const started = performance.now();
   const res = await tauriFetch(SWITCHER_URL, {
     method: "GET",
     headers: {
@@ -52,6 +54,10 @@ export async function fetchChannelList(): Promise<ChannelChoice[]> {
       "Accept-Language": "en-US,en;q=0.9",
     },
   });
+  diagLog(
+    "network",
+    `account switcher GET ${res.status} ${Math.round(performance.now() - started)}ms`,
+  );
   // This page-level endpoint is the one that mints the post-login
   // LOGIN_INFO / SIDCC burst; echoing it into the jar is what keeps
   // the fresh session alive (see captureSetCookies).

--- a/src/lib/innertube/shared.ts
+++ b/src/lib/innertube/shared.ts
@@ -1,5 +1,6 @@
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
 import { invoke } from "@tauri-apps/api/core";
+import { diagLog } from "@/lib/diagnostics";
 import type { ShelfItem, ShelfMore, Thumbnail } from "./types";
 
 export type YtNode = Record<string, any>;
@@ -252,11 +253,16 @@ export async function innertubePost(
   const visitorHeader: Record<string, string> = visitor
     ? { "X-Goog-Visitor-Id": visitor }
     : {};
+  const started = performance.now();
   const res = await tauriFetch(url, {
     method: "POST",
     headers: { ...BASE_HEADERS, ...visitorHeader, ...auth },
     body: JSON.stringify({ context: buildContext(), ...body }),
   });
+  diagLog(
+    "network",
+    `innertube ${endpoint} ${res.status} ${Math.round(performance.now() - started)}ms`,
+  );
 
   // Before the error bail: Google rotates cookies on 4xx responses too.
   await captureSetCookies(res);

--- a/src/lib/interaction-logger.ts
+++ b/src/lib/interaction-logger.ts
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import { diagLog } from "@/lib/diagnostics";
+
+const INTERACTIVE_SELECTOR = [
+  "button",
+  "a[href]",
+  "[role=\"button\"]",
+  "[role=\"menuitem\"]",
+  "[role=\"tab\"]",
+  "[role=\"switch\"]",
+  "[role=\"checkbox\"]",
+  "[role=\"radio\"]",
+  "input[type=\"button\"]",
+  "input[type=\"submit\"]",
+  "input[type=\"checkbox\"]",
+  "input[type=\"radio\"]",
+  "select",
+].join(", ");
+
+function describeElement(el: Element): string {
+  const label = el.getAttribute("aria-label") || el.getAttribute("title");
+  if (label) return label;
+  const text = el.textContent?.trim().replace(/\s+/g, " ").slice(0, 60);
+  if (text) return text;
+  return el.tagName.toLowerCase();
+}
+
+export function useInteractionLogger(): void {
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      const target = e.target;
+      if (!(target instanceof Element)) return;
+      const el = target.closest(INTERACTIVE_SELECTOR);
+      if (!el) return;
+      diagLog("ui", `click ${describeElement(el)}`);
+    };
+    const onSubmit = (e: SubmitEvent) => {
+      const target = e.target;
+      if (!(target instanceof HTMLFormElement)) return;
+      diagLog("ui", `submit ${target.getAttribute("aria-label") || target.name || "form"}`);
+    };
+    document.addEventListener("click", onClick, true);
+    document.addEventListener("submit", onSubmit, true);
+    return () => {
+      document.removeEventListener("click", onClick, true);
+      document.removeEventListener("submit", onSubmit, true);
+    };
+  }, []);
+}

--- a/src/lib/lyrics/http.ts
+++ b/src/lib/lyrics/http.ts
@@ -1,4 +1,5 @@
 import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { diagLog } from "@/lib/diagnostics";
 
 /**
  * Shared request plumbing for the lyrics providers, with one job: keep the
@@ -132,14 +133,25 @@ export async function lyricsFetch(
   /** JSON body. Its presence switches the request to POST. */
   body?: unknown,
 ): Promise<Response> {
+  const method = body === undefined ? "GET" : "POST";
+  const started = performance.now();
   try {
-    return await tauriFetch(url, {
-      method: body === undefined ? "GET" : "POST",
+    const res = await tauriFetch(url, {
+      method,
       headers,
       body: body === undefined ? undefined : JSON.stringify(body),
       signal: deadline.signal,
     });
+    diagLog(
+      "network",
+      `${safeHost(url)} ${method} ${res.status} ${Math.round(performance.now() - started)}ms`,
+    );
+    return res;
   } catch (e) {
+    diagLog(
+      "network",
+      `${safeHost(url)} ${method} failed ${Math.round(performance.now() - started)}ms`,
+    );
     if (deadline.timedOut()) throw new LyricsTimeoutError(PROVIDER_TIMEOUT_MS);
     // An upstream abort (track changed, component unmounted) is not a
     // failure worth reporting. Re-throw it as-is so React Query recognises

--- a/src/lib/store/settings-dialog.ts
+++ b/src/lib/store/settings-dialog.ts
@@ -4,7 +4,8 @@ export type SettingsTab =
   | "general"
   | "appearance"
   | "storage"
-  | "integrations";
+  | "integrations"
+  | "help";
 
 type State = {
   open: boolean;

--- a/src/lib/store/settings.ts
+++ b/src/lib/store/settings.ts
@@ -43,6 +43,7 @@ type State = {
    *  scrobbling and off by default: an opt-in, since people often keep their
    *  likes intentionally different per platform. See `lib/lastfm.ts`. */
   lastfmLoveSync: boolean;
+  debugConsoleEnabled: boolean;
   setCloseAction: (v: CloseButtonAction) => void;
   setCacheAutoClean: (v: CacheAutoCleanPeriod) => void;
   markCacheCleaned: () => void;
@@ -56,6 +57,7 @@ type State = {
   setLastfmSession: (username: string, sessionKey: string) => void;
   /** Forget the connected account and stop scrobbling. */
   clearLastfmSession: () => void;
+  setDebugConsoleEnabled: (v: boolean) => void;
 };
 
 /**
@@ -78,6 +80,7 @@ export const useSettingsStore = create<State>()(
       lastfmUsername: null,
       lastfmAvatar: null,
       lastfmLoveSync: false,
+      debugConsoleEnabled: false,
       setCloseAction: (closeAction) => set({ closeAction }),
       setCacheAutoClean: (cacheAutoClean) => set({ cacheAutoClean }),
       markCacheCleaned: () => set({ lastCacheCleanAt: Date.now() }),
@@ -99,6 +102,7 @@ export const useSettingsStore = create<State>()(
           lastfmEnabled: false,
           lastfmLoveSync: false,
         }),
+      setDebugConsoleEnabled: (debugConsoleEnabled) => set({ debugConsoleEnabled }),
     }),
     { name: "ytm-settings" },
   ),
@@ -147,5 +151,12 @@ export function useDiscordPresenceSync(): void {
     invoke("discord_set_enabled", { enabled }).catch(() => {
       /* plain-vite dev without a Tauri backend — nothing to sync */
     });
+  }, [enabled]);
+}
+
+export function useDebugConsoleSync(): void {
+  const enabled = useSettingsStore((s) => s.debugConsoleEnabled);
+  useEffect(() => {
+    invoke(enabled ? "open_diag_window" : "close_diag_window").catch(() => {});
   }, [enabled]);
 }


### PR DESCRIPTION
Adds a toggleable in-app debug console (Settings -> Help) for diagnosing playback and network issues without needing to run the app under a debugger.

- A new `diagnostics` Rust module (`diagnostics::note`) and matching frontend helper (`diagLog`) feed a shared ring buffer that a hidden diagnostics window renders live.
- Adds network timing/status logging and UI logging behind the same toggle.
- The Help tab also absorbs the existing Check for updates, Report an issue, and About entries into one place.

Off by default, no behavior change when disabled beyond the log calls themselves.

There will be two more PRs to fix other player issues.