### PR TITLE
fix(ytdlp): check for updates during long tray sessions

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2688,6 +2688,12 @@ async fn ensure_ytdlp(app: tauri::AppHandle) {
     ytdlp::ensure(app).await;
 }
 
+/// Throttled update check for a process that remains alive in the tray.
+#[tauri::command]
+async fn check_ytdlp_update(app: tauri::AppHandle) {
+    ytdlp::check_update(app).await;
+}
+
 /// Run yt-dlp to resolve a videoId into metadata JSON.
 #[tauri::command]
 fn resolve_stream_ytdlp(app: tauri::AppHandle, video_id: String) -> Result<String, String> {
@@ -3715,6 +3721,7 @@ pub fn run() {
         .manage(lastfm::LastfmState::default())
         .invoke_handler(tauri::generate_handler![
             ensure_ytdlp,
+            check_ytdlp_update,
             resolve_stream_ytdlp,
             get_stream_base_url,
             start_login,

--- a/src-tauri/src/ytdlp.rs
+++ b/src-tauri/src/ytdlp.rs
@@ -120,6 +120,10 @@ fn emit_state(app: &tauri::AppHandle, phase: &str, message: Option<String>) {
     );
 }
 
+// Setup, manual retries and the long-session timer can overlap. One lock keeps
+// them from updating or replacing the managed binary concurrently.
+static ENSURE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 /// Idempotent "make yt-dlp available" entry point. Called from the
 /// frontend on every launch (so the webview's event listener is
 /// guaranteed to be mounted before any state event fires) and safe to
@@ -128,8 +132,7 @@ fn emit_state(app: &tauri::AppHandle, phase: &str, message: Option<String>) {
 /// Emits `ytdlp-state` events: `downloading` → `ready` | `error`.
 pub async fn ensure(app: tauri::AppHandle) {
     // Serialize concurrent calls (StrictMode double-mount, retry spam).
-    static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-    let _guard = LOCK.lock().await;
+    let _guard = ENSURE_LOCK.lock().await;
 
     let managed = managed_path(&app);
 
@@ -173,6 +176,16 @@ pub async fn ensure(app: tauri::AppHandle) {
                 emit_state(&app, "error", Some(e));
             }
         }
+    }
+}
+
+/// Check an existing managed copy for an update without repeating first-run
+/// setup, readiness events, or macOS prewarming and legacy cleanup.
+pub async fn check_update(app: tauri::AppHandle) {
+    let _guard = ENSURE_LOCK.lock().await;
+    let managed = managed_path(&app);
+    if managed.exists() {
+        maybe_self_update(&managed).await;
     }
 }
 

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -9,6 +9,10 @@ type YtdlpState = {
 };
 
 const TOAST_ID = "ytdlp-setup";
+// `ensure_ytdlp` does no network work until its 72-hour stamp expires. Polling
+// hourly keeps a tray-resident process close to that cadence without turning
+// a launch-time check into a second scheduler on the Rust side.
+const UPDATE_POLL_INTERVAL_MS = 60 * 60 * 1000;
 
 /**
  * Mount once in AppShell. Kicks off `ensure_ytdlp` on the Rust side
@@ -28,6 +32,13 @@ export function useYtdlpSetup(): void {
   useEffect(() => {
     let cancelled = false;
     let dispose: (() => void) | undefined;
+    let updateTimer: number | undefined;
+
+    const ensureYtdlp = () => {
+      void invoke("ensure_ytdlp").catch((err) => {
+        console.error("[ytdlp] ensure_ytdlp failed:", err);
+      });
+    };
 
     void listen<YtdlpState>("ytdlp-state", (e) => {
       const { phase, message } = e.payload;
@@ -63,14 +74,17 @@ export function useYtdlpSetup(): void {
       }
       dispose = un;
       // Listener is live — safe to start the Rust side now.
-      void invoke("ensure_ytdlp").catch((err) => {
-        console.error("[ytdlp] ensure_ytdlp failed:", err);
-      });
+      ensureYtdlp();
+      // Closing the main window hides this process to the tray by default,
+      // so it may not launch again for weeks. Keep checking while it lives;
+      // the Rust-side stamp makes every early poll a local no-op.
+      updateTimer = window.setInterval(ensureYtdlp, UPDATE_POLL_INTERVAL_MS);
     });
 
     return () => {
       cancelled = true;
       dispose?.();
+      if (updateTimer !== undefined) window.clearInterval(updateTimer);
     };
   }, []);
 }

--- a/src/lib/ytdlp.ts
+++ b/src/lib/ytdlp.ts
@@ -34,9 +34,11 @@ export function useYtdlpSetup(): void {
     let dispose: (() => void) | undefined;
     let updateTimer: number | undefined;
 
-    const ensureYtdlp = () => {
-      void invoke("ensure_ytdlp").catch((err) => {
-        console.error("[ytdlp] ensure_ytdlp failed:", err);
+    const runYtdlpCommand = (
+      command: "ensure_ytdlp" | "check_ytdlp_update",
+    ) => {
+      void invoke(command).catch((err) => {
+        console.error(`[ytdlp] ${command} failed:`, err);
       });
     };
 
@@ -62,7 +64,7 @@ export function useYtdlpSetup(): void {
           action: {
             label: "Retry",
             onClick: () => {
-              void invoke("ensure_ytdlp");
+              runYtdlpCommand("ensure_ytdlp");
             },
           },
         });
@@ -74,11 +76,14 @@ export function useYtdlpSetup(): void {
       }
       dispose = un;
       // Listener is live — safe to start the Rust side now.
-      ensureYtdlp();
+      runYtdlpCommand("ensure_ytdlp");
       // Closing the main window hides this process to the tray by default,
       // so it may not launch again for weeks. Keep checking while it lives;
       // the Rust-side stamp makes every early poll a local no-op.
-      updateTimer = window.setInterval(ensureYtdlp, UPDATE_POLL_INTERVAL_MS);
+      updateTimer = window.setInterval(
+        () => runYtdlpCommand("check_ytdlp_update"),
+        UPDATE_POLL_INTERVAL_MS,
+      );
     });
 
     return () => {


### PR DESCRIPTION
## Motivation

Closing YTubic hides it to the tray by default, so the process can stay alive for days and never run the launch-only yt-dlp update check. The existing 72-hour cadence can therefore be missed indefinitely. My running version used yt-dlp from August 14 and stopped working today.

## Implementation

- Poll hourly while the app process is alive.
- Keep the existing Rust-side 72-hour throttle, so early polls stay local.
- Use a dedicated update-only command guarded by the same mutex as setup and retry.
- Avoid repeating readiness events, first-run setup, macOS prewarming, or legacy cleanup.

## Testing

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` - 21 passed
- `pnpm test` - 229 passed
- `pnpm build`