### PR TITLE
fix(ytdlp): show version and last update check in About

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2688,12 +2688,6 @@ async fn ensure_ytdlp(app: tauri::AppHandle) {
     ytdlp::ensure(app).await;
 }
 
-/// Read bounded, non-networked audio-engine diagnostics for About.
-#[tauri::command]
-async fn get_ytdlp_diagnostics(app: tauri::AppHandle) -> ytdlp::Diagnostics {
-    ytdlp::diagnostics(&app).await
-}
-
 /// Run yt-dlp to resolve a videoId into metadata JSON.
 #[tauri::command]
 fn resolve_stream_ytdlp(app: tauri::AppHandle, video_id: String) -> Result<String, String> {
@@ -2731,6 +2725,12 @@ fn resolve_stream_ytdlp(app: tauri::AppHandle, video_id: String) -> Result<Strin
         ));
     }
     String::from_utf8(output.stdout).map_err(|e| format!("stdout not utf8: {e}"))
+}
+
+/// Read bounded, non-networked audio-engine diagnostics for About.
+#[tauri::command]
+async fn get_ytdlp_diagnostics(app: tauri::AppHandle) -> ytdlp::Diagnostics {
+    ytdlp::diagnostics(&app).await
 }
 
 /// Lifecycle of a single track's yt-dlp download. yt-dlp writes
@@ -3721,7 +3721,6 @@ pub fn run() {
         .manage(lastfm::LastfmState::default())
         .invoke_handler(tauri::generate_handler![
             ensure_ytdlp,
-            get_ytdlp_diagnostics,
             resolve_stream_ytdlp,
             get_stream_base_url,
             start_login,
@@ -3751,6 +3750,7 @@ pub fn run() {
             autostart_is_enabled,
             notify_track,
             get_cache_dir,
+            get_ytdlp_diagnostics,
             set_cache_dir,
             pick_cache_folder,
             focus_main_window,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2688,13 +2688,6 @@ async fn ensure_ytdlp(app: tauri::AppHandle) {
     ytdlp::ensure(app).await;
 }
 
-/// Read the managed audio engine's installed version and persisted update
-/// history for the About dialog. This performs no update or network request.
-#[tauri::command]
-async fn get_ytdlp_diagnostics(app: tauri::AppHandle) -> ytdlp::Diagnostics {
-    ytdlp::diagnostics(&app).await
-}
-
 /// Run yt-dlp to resolve a videoId into metadata JSON.
 #[tauri::command]
 fn resolve_stream_ytdlp(app: tauri::AppHandle, video_id: String) -> Result<String, String> {
@@ -3722,7 +3715,6 @@ pub fn run() {
         .manage(lastfm::LastfmState::default())
         .invoke_handler(tauri::generate_handler![
             ensure_ytdlp,
-            get_ytdlp_diagnostics,
             resolve_stream_ytdlp,
             get_stream_base_url,
             start_login,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2688,6 +2688,13 @@ async fn ensure_ytdlp(app: tauri::AppHandle) {
     ytdlp::ensure(app).await;
 }
 
+/// Read the managed audio engine's installed version and persisted update
+/// history for the About dialog. This performs no update or network request.
+#[tauri::command]
+async fn get_ytdlp_diagnostics(app: tauri::AppHandle) -> ytdlp::Diagnostics {
+    ytdlp::diagnostics(&app).await
+}
+
 /// Run yt-dlp to resolve a videoId into metadata JSON.
 #[tauri::command]
 fn resolve_stream_ytdlp(app: tauri::AppHandle, video_id: String) -> Result<String, String> {
@@ -3715,6 +3722,7 @@ pub fn run() {
         .manage(lastfm::LastfmState::default())
         .invoke_handler(tauri::generate_handler![
             ensure_ytdlp,
+            get_ytdlp_diagnostics,
             resolve_stream_ytdlp,
             get_stream_base_url,
             start_login,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2688,6 +2688,12 @@ async fn ensure_ytdlp(app: tauri::AppHandle) {
     ytdlp::ensure(app).await;
 }
 
+/// Read bounded, non-networked audio-engine diagnostics for About.
+#[tauri::command]
+async fn get_ytdlp_diagnostics(app: tauri::AppHandle) -> ytdlp::Diagnostics {
+    ytdlp::diagnostics(&app).await
+}
+
 /// Run yt-dlp to resolve a videoId into metadata JSON.
 #[tauri::command]
 fn resolve_stream_ytdlp(app: tauri::AppHandle, video_id: String) -> Result<String, String> {
@@ -3715,6 +3721,7 @@ pub fn run() {
         .manage(lastfm::LastfmState::default())
         .invoke_handler(tauri::generate_handler![
             ensure_ytdlp,
+            get_ytdlp_diagnostics,
             resolve_stream_ytdlp,
             get_stream_base_url,
             start_login,

--- a/src-tauri/src/ytdlp.rs
+++ b/src-tauri/src/ytdlp.rs
@@ -160,7 +160,6 @@ pub async fn ensure(app: tauri::AppHandle) {
         Ok(()) => {
             eprintln!("[ytdlp] downloaded managed binary to {managed:?}");
             touch_update_stamp(&managed);
-            write_update_result(&managed, &Ok("Installed managed copy".to_string()));
             #[cfg(target_os = "macos")]
             {
                 prewarm(&managed);
@@ -170,7 +169,6 @@ pub async fn ensure(app: tauri::AppHandle) {
         }
         Err(e) => {
             eprintln!("[ytdlp] download failed: {e}");
-            write_update_result(&managed, &Err(e.clone()));
             if !path_works {
                 emit_state(&app, "error", Some(e));
             }
@@ -383,58 +381,6 @@ fn update_stamp_path(managed: &Path) -> PathBuf {
     install_root(managed).join("last-update-check")
 }
 
-fn update_result_path(managed: &Path) -> PathBuf {
-    install_root(managed).join("last-update-result.json")
-}
-
-#[derive(Clone, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UpdateResult {
-    pub success: bool,
-    pub message: String,
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Diagnostics {
-    pub version: Option<String>,
-    pub last_check_at: Option<u64>,
-    pub last_result: Option<UpdateResult>,
-}
-
-fn write_update_result(managed: &Path, result: &Result<String, String>) {
-    let stored = match result {
-        Ok(message) => UpdateResult {
-            success: true,
-            message: message.clone(),
-        },
-        Err(message) => UpdateResult {
-            success: false,
-            message: message.clone(),
-        },
-    };
-    if let Ok(json) = serde_json::to_vec(&stored) {
-        let _ = std::fs::write(update_result_path(managed), json);
-    }
-}
-
-fn update_stamp_time(managed: &Path) -> Option<u64> {
-    let raw = std::fs::read_to_string(update_stamp_path(managed)).ok()?;
-    raw.trim().parse().ok()
-}
-
-pub async fn diagnostics(app: &tauri::AppHandle) -> Diagnostics {
-    let managed = managed_path(app);
-    let last_result = std::fs::read(update_result_path(&managed))
-        .ok()
-        .and_then(|json| serde_json::from_slice(&json).ok());
-    Diagnostics {
-        version: installed_version(&managed).await,
-        last_check_at: update_stamp_time(&managed),
-        last_result,
-    }
-}
-
 fn touch_update_stamp(managed: &Path) {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -444,7 +390,8 @@ fn touch_update_stamp(managed: &Path) {
 }
 
 fn update_stamp_age(managed: &Path) -> Option<Duration> {
-    let then = update_stamp_time(managed)?;
+    let raw = std::fs::read_to_string(update_stamp_path(managed)).ok()?;
+    let then = raw.trim().parse::<u64>().ok()?;
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -463,10 +410,9 @@ async fn maybe_self_update(managed: &Path) {
     touch_update_stamp(managed);
 
     #[cfg(target_os = "macos")]
-    let result = update_bundle(managed).await;
+    update_bundle(managed).await;
     #[cfg(not(target_os = "macos"))]
-    let result = run_self_update(managed).await;
-    write_update_result(managed, &result);
+    run_self_update(managed).await;
 }
 
 /// macOS replacement for `-U`: yt-dlp's updater refuses to touch a
@@ -474,15 +420,14 @@ async fn maybe_self_update(managed: &Path) {
 /// executables"), so compare the installed version against the newest
 /// release ourselves and re-install the bundle when they differ.
 #[cfg(target_os = "macos")]
-async fn update_bundle(managed: &Path) -> Result<String, String> {
+async fn update_bundle(managed: &Path) {
     let Some(latest) = latest_release_tag().await else {
-        let message = "Could not read the latest release tag; kept the current copy".to_string();
-        eprintln!("[ytdlp] {message}");
-        return Err(message);
+        eprintln!("[ytdlp] could not read the latest release tag; keeping the current copy");
+        return;
     };
     let installed = installed_version(managed).await;
     if installed.as_deref() == Some(latest.as_str()) {
-        return Ok(format!("Already up to date ({latest})"));
+        return;
     }
     eprintln!(
         "[ytdlp] updating {} -> {latest}",
@@ -494,12 +439,8 @@ async fn update_bundle(managed: &Path) -> Result<String, String> {
         Ok(()) => {
             eprintln!("[ytdlp] updated to {latest}");
             prewarm(managed);
-            Ok(format!("Updated to {latest}"))
         }
-        Err(e) => {
-            eprintln!("[ytdlp] update failed: {e}");
-            Err(format!("Update failed: {e}"))
-        }
+        Err(e) => eprintln!("[ytdlp] update failed: {e}"),
     }
 }
 
@@ -545,7 +486,7 @@ async fn installed_version(managed: &Path) -> Option<String> {
 
 /// Windows / Linux: the single-file release replaces itself in place.
 #[cfg(not(target_os = "macos"))]
-async fn run_self_update(managed: &Path) -> Result<String, String> {
+async fn run_self_update(managed: &Path) {
     let mut cmd = tokio::process::Command::new(managed);
     cmd.arg("-U");
     #[cfg(windows)]
@@ -556,19 +497,22 @@ async fn run_self_update(managed: &Path) -> Result<String, String> {
     // wedged child would outlive it as an orphan.
     cmd.kill_on_drop(true);
 
-    let run = tokio::time::timeout(UPDATE_TIMEOUT, cmd.output()).await;
-    match run {
-        Ok(Ok(out)) => {
-            let stdout = String::from_utf8_lossy(&out.stdout);
-            let line = stdout
-                .lines()
-                .rev()
-                .find(|l| !l.trim().is_empty())
-                .unwrap_or("");
-            eprintln!("[ytdlp] self-update ({}): {line}", out.status);
+    let run = async {
+        match cmd.output().await {
+            Ok(out) => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                let line = stdout
+                    .lines()
+                    .rev()
+                    .find(|l| !l.trim().is_empty())
+                    .unwrap_or("");
+                eprintln!("[ytdlp] self-update ({}): {line}", out.status);
+            }
+            Err(e) => eprintln!("[ytdlp] self-update spawn failed: {e}"),
         }
-        Ok(Err(e)) => eprintln!("[ytdlp] self-update spawn failed: {e}"),
-        Err(_) => eprintln!("[ytdlp] self-update timed out"),
+    };
+    if tokio::time::timeout(UPDATE_TIMEOUT, run).await.is_err() {
+        eprintln!("[ytdlp] self-update timed out");
     }
 
     // `-U` reports its own success and can still leave the old copy in
@@ -578,51 +522,15 @@ async fn run_self_update(managed: &Path) -> Result<String, String> {
     // actually moved, and fall back to re-fetching the release asset when
     // it didn't. Same path the first-run download takes.
     let Some(latest) = latest_release_tag().await else {
-        return Err("Could not read the latest release tag".to_string());
+        return;
     };
     if installed_version(managed).await.as_deref() == Some(latest.as_str()) {
-        return Ok(format!("Already up to date ({latest})"));
+        return;
     }
     eprintln!("[ytdlp] self-update left us behind {latest}; re-downloading");
     match download(managed).await {
-        Ok(()) => {
-            eprintln!("[ytdlp] re-downloaded {latest}");
-            Ok(format!("Updated to {latest}"))
-        }
-        Err(e) => {
-            eprintln!("[ytdlp] re-download failed: {e}");
-            Err(format!("Update failed: {e}"))
-        }
-    }
-}
-
-#[cfg(test)]
-mod diagnostics_tests {
-    use super::*;
-
-    #[test]
-    fn update_diagnostics_sidecars_round_trip() {
-        let root = std::env::temp_dir().join(format!(
-            "ytubic-ytdlp-diagnostics-{}",
-            std::process::id()
-        ));
-        let _ = std::fs::remove_dir_all(&root);
-        std::fs::create_dir_all(&root).unwrap();
-        #[cfg(target_os = "macos")]
-        let managed = root.join(MACOS_BUNDLE_DIR).join(BINARY_NAME);
-        #[cfg(not(target_os = "macos"))]
-        let managed = root.join(BINARY_NAME);
-
-        std::fs::write(update_stamp_path(&managed), "1787263200").unwrap();
-        write_update_result(&managed, &Err("network unavailable".to_string()));
-
-        assert_eq!(update_stamp_time(&managed), Some(1787263200));
-        let stored: UpdateResult =
-            serde_json::from_slice(&std::fs::read(update_result_path(&managed)).unwrap()).unwrap();
-        assert!(!stored.success);
-        assert_eq!(stored.message, "network unavailable");
-
-        let _ = std::fs::remove_dir_all(root);
+        Ok(()) => eprintln!("[ytdlp] re-downloaded {latest}"),
+        Err(e) => eprintln!("[ytdlp] re-download failed: {e}"),
     }
 }
 

--- a/src-tauri/src/ytdlp.rs
+++ b/src-tauri/src/ytdlp.rs
@@ -160,6 +160,7 @@ pub async fn ensure(app: tauri::AppHandle) {
         Ok(()) => {
             eprintln!("[ytdlp] downloaded managed binary to {managed:?}");
             touch_update_stamp(&managed);
+            write_update_result(&managed, &Ok("Installed managed copy".to_string()));
             #[cfg(target_os = "macos")]
             {
                 prewarm(&managed);
@@ -169,6 +170,7 @@ pub async fn ensure(app: tauri::AppHandle) {
         }
         Err(e) => {
             eprintln!("[ytdlp] download failed: {e}");
+            write_update_result(&managed, &Err(e.clone()));
             if !path_works {
                 emit_state(&app, "error", Some(e));
             }
@@ -381,6 +383,58 @@ fn update_stamp_path(managed: &Path) -> PathBuf {
     install_root(managed).join("last-update-check")
 }
 
+fn update_result_path(managed: &Path) -> PathBuf {
+    install_root(managed).join("last-update-result.json")
+}
+
+#[derive(Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateResult {
+    pub success: bool,
+    pub message: String,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Diagnostics {
+    pub version: Option<String>,
+    pub last_check_at: Option<u64>,
+    pub last_result: Option<UpdateResult>,
+}
+
+fn write_update_result(managed: &Path, result: &Result<String, String>) {
+    let stored = match result {
+        Ok(message) => UpdateResult {
+            success: true,
+            message: message.clone(),
+        },
+        Err(message) => UpdateResult {
+            success: false,
+            message: message.clone(),
+        },
+    };
+    if let Ok(json) = serde_json::to_vec(&stored) {
+        let _ = std::fs::write(update_result_path(managed), json);
+    }
+}
+
+fn update_stamp_time(managed: &Path) -> Option<u64> {
+    let raw = std::fs::read_to_string(update_stamp_path(managed)).ok()?;
+    raw.trim().parse().ok()
+}
+
+pub async fn diagnostics(app: &tauri::AppHandle) -> Diagnostics {
+    let managed = managed_path(app);
+    let last_result = std::fs::read(update_result_path(&managed))
+        .ok()
+        .and_then(|json| serde_json::from_slice(&json).ok());
+    Diagnostics {
+        version: installed_version(&managed).await,
+        last_check_at: update_stamp_time(&managed),
+        last_result,
+    }
+}
+
 fn touch_update_stamp(managed: &Path) {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -390,8 +444,7 @@ fn touch_update_stamp(managed: &Path) {
 }
 
 fn update_stamp_age(managed: &Path) -> Option<Duration> {
-    let raw = std::fs::read_to_string(update_stamp_path(managed)).ok()?;
-    let then = raw.trim().parse::<u64>().ok()?;
+    let then = update_stamp_time(managed)?;
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -410,9 +463,10 @@ async fn maybe_self_update(managed: &Path) {
     touch_update_stamp(managed);
 
     #[cfg(target_os = "macos")]
-    update_bundle(managed).await;
+    let result = update_bundle(managed).await;
     #[cfg(not(target_os = "macos"))]
-    run_self_update(managed).await;
+    let result = run_self_update(managed).await;
+    write_update_result(managed, &result);
 }
 
 /// macOS replacement for `-U`: yt-dlp's updater refuses to touch a
@@ -420,14 +474,15 @@ async fn maybe_self_update(managed: &Path) {
 /// executables"), so compare the installed version against the newest
 /// release ourselves and re-install the bundle when they differ.
 #[cfg(target_os = "macos")]
-async fn update_bundle(managed: &Path) {
+async fn update_bundle(managed: &Path) -> Result<String, String> {
     let Some(latest) = latest_release_tag().await else {
-        eprintln!("[ytdlp] could not read the latest release tag; keeping the current copy");
-        return;
+        let message = "Could not read the latest release tag; kept the current copy".to_string();
+        eprintln!("[ytdlp] {message}");
+        return Err(message);
     };
     let installed = installed_version(managed).await;
     if installed.as_deref() == Some(latest.as_str()) {
-        return;
+        return Ok(format!("Already up to date ({latest})"));
     }
     eprintln!(
         "[ytdlp] updating {} -> {latest}",
@@ -439,8 +494,12 @@ async fn update_bundle(managed: &Path) {
         Ok(()) => {
             eprintln!("[ytdlp] updated to {latest}");
             prewarm(managed);
+            Ok(format!("Updated to {latest}"))
         }
-        Err(e) => eprintln!("[ytdlp] update failed: {e}"),
+        Err(e) => {
+            eprintln!("[ytdlp] update failed: {e}");
+            Err(format!("Update failed: {e}"))
+        }
     }
 }
 
@@ -486,7 +545,7 @@ async fn installed_version(managed: &Path) -> Option<String> {
 
 /// Windows / Linux: the single-file release replaces itself in place.
 #[cfg(not(target_os = "macos"))]
-async fn run_self_update(managed: &Path) {
+async fn run_self_update(managed: &Path) -> Result<String, String> {
     let mut cmd = tokio::process::Command::new(managed);
     cmd.arg("-U");
     #[cfg(windows)]
@@ -497,22 +556,19 @@ async fn run_self_update(managed: &Path) {
     // wedged child would outlive it as an orphan.
     cmd.kill_on_drop(true);
 
-    let run = async {
-        match cmd.output().await {
-            Ok(out) => {
-                let stdout = String::from_utf8_lossy(&out.stdout);
-                let line = stdout
-                    .lines()
-                    .rev()
-                    .find(|l| !l.trim().is_empty())
-                    .unwrap_or("");
-                eprintln!("[ytdlp] self-update ({}): {line}", out.status);
-            }
-            Err(e) => eprintln!("[ytdlp] self-update spawn failed: {e}"),
+    let run = tokio::time::timeout(UPDATE_TIMEOUT, cmd.output()).await;
+    match run {
+        Ok(Ok(out)) => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let line = stdout
+                .lines()
+                .rev()
+                .find(|l| !l.trim().is_empty())
+                .unwrap_or("");
+            eprintln!("[ytdlp] self-update ({}): {line}", out.status);
         }
-    };
-    if tokio::time::timeout(UPDATE_TIMEOUT, run).await.is_err() {
-        eprintln!("[ytdlp] self-update timed out");
+        Ok(Err(e)) => eprintln!("[ytdlp] self-update spawn failed: {e}"),
+        Err(_) => eprintln!("[ytdlp] self-update timed out"),
     }
 
     // `-U` reports its own success and can still leave the old copy in
@@ -522,15 +578,51 @@ async fn run_self_update(managed: &Path) {
     // actually moved, and fall back to re-fetching the release asset when
     // it didn't. Same path the first-run download takes.
     let Some(latest) = latest_release_tag().await else {
-        return;
+        return Err("Could not read the latest release tag".to_string());
     };
     if installed_version(managed).await.as_deref() == Some(latest.as_str()) {
-        return;
+        return Ok(format!("Already up to date ({latest})"));
     }
     eprintln!("[ytdlp] self-update left us behind {latest}; re-downloading");
     match download(managed).await {
-        Ok(()) => eprintln!("[ytdlp] re-downloaded {latest}"),
-        Err(e) => eprintln!("[ytdlp] re-download failed: {e}"),
+        Ok(()) => {
+            eprintln!("[ytdlp] re-downloaded {latest}");
+            Ok(format!("Updated to {latest}"))
+        }
+        Err(e) => {
+            eprintln!("[ytdlp] re-download failed: {e}");
+            Err(format!("Update failed: {e}"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod diagnostics_tests {
+    use super::*;
+
+    #[test]
+    fn update_diagnostics_sidecars_round_trip() {
+        let root = std::env::temp_dir().join(format!(
+            "ytubic-ytdlp-diagnostics-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        #[cfg(target_os = "macos")]
+        let managed = root.join(MACOS_BUNDLE_DIR).join(BINARY_NAME);
+        #[cfg(not(target_os = "macos"))]
+        let managed = root.join(BINARY_NAME);
+
+        std::fs::write(update_stamp_path(&managed), "1787263200").unwrap();
+        write_update_result(&managed, &Err("network unavailable".to_string()));
+
+        assert_eq!(update_stamp_time(&managed), Some(1787263200));
+        let stored: UpdateResult =
+            serde_json::from_slice(&std::fs::read(update_result_path(&managed)).unwrap()).unwrap();
+        assert!(!stored.success);
+        assert_eq!(stored.message, "network unavailable");
+
+        let _ = std::fs::remove_dir_all(root);
     }
 }
 

--- a/src-tauri/src/ytdlp.rs
+++ b/src-tauri/src/ytdlp.rs
@@ -68,6 +68,9 @@ const DOWNLOAD_URL: &str =
 
 /// How often to let the managed copy check for an update.
 const UPDATE_INTERVAL: Duration = Duration::from_secs(72 * 60 * 60);
+/// Bound version probes used by update verification and the About dialog.
+/// The cold macOS directory bundle can legitimately take about 30 seconds.
+const VERSION_TIMEOUT: Duration = Duration::from_secs(45);
 /// Hard cap on the `-U` self-update run.
 #[cfg(not(target_os = "macos"))]
 const UPDATE_TIMEOUT: Duration = Duration::from_secs(180);
@@ -381,6 +384,28 @@ fn update_stamp_path(managed: &Path) -> PathBuf {
     install_root(managed).join("last-update-check")
 }
 
+fn update_stamp_time(managed: &Path) -> Option<u64> {
+    let raw = std::fs::read_to_string(update_stamp_path(managed)).ok()?;
+    raw.trim().parse().ok()
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Diagnostics {
+    pub version: Option<String>,
+    pub last_check_at: Option<u64>,
+}
+
+/// Read the managed version and existing persistent update stamp. No update
+/// or network request is performed, and the subprocess probe is bounded.
+pub async fn diagnostics(app: &tauri::AppHandle) -> Diagnostics {
+    let managed = managed_path(app);
+    Diagnostics {
+        version: installed_version(&managed).await,
+        last_check_at: update_stamp_time(&managed),
+    }
+}
+
 fn touch_update_stamp(managed: &Path) {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -390,8 +415,7 @@ fn touch_update_stamp(managed: &Path) {
 }
 
 fn update_stamp_age(managed: &Path) -> Option<Duration> {
-    let raw = std::fs::read_to_string(update_stamp_path(managed)).ok()?;
-    let then = raw.trim().parse::<u64>().ok()?;
+    let then = update_stamp_time(managed)?;
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -472,7 +496,11 @@ async fn installed_version(managed: &Path) -> Option<String> {
     cmd.arg("--version");
     #[cfg(windows)]
     cmd.creation_flags(CREATE_NO_WINDOW);
-    let out = cmd.output().await.ok()?;
+    cmd.kill_on_drop(true);
+    let out = tokio::time::timeout(VERSION_TIMEOUT, cmd.output())
+        .await
+        .ok()?
+        .ok()?;
     if !out.status.success() {
         return None;
     }

--- a/src/components/layout/about-dialog.tsx
+++ b/src/components/layout/about-dialog.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { getVersion } from "@tauri-apps/api/app";
-import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   Dialog,
@@ -20,12 +19,6 @@ import { DiscordIcon, GithubIcon } from "@/components/shared/brand-icons";
 
 const REPO_URL = "https://github.com/NUber-dev/YTubic";
 const DISCORD_URL = "https://discord.gg/4gccUpZyYH";
-
-type YtdlpDiagnostics = {
-  version: string | null;
-  lastCheckAt: number | null;
-  lastResult: { success: boolean; message: string } | null;
-};
 
 const CREDITS: { name: string; role: string; url: string }[] = [
   {
@@ -54,16 +47,12 @@ export function AboutDialog({
   onOpenChange: (v: boolean) => void;
 }) {
   const [version, setVersion] = useState<string>("");
-  const [ytdlp, setYtdlp] = useState<YtdlpDiagnostics | null>(null);
 
   useEffect(() => {
     if (!open) return;
     getVersion()
       .then(setVersion)
       .catch(() => setVersion(""));
-    invoke<YtdlpDiagnostics>("get_ytdlp_diagnostics")
-      .then(setYtdlp)
-      .catch(() => setYtdlp(null));
   }, [open]);
 
   const link = (url: string) => () => {
@@ -122,36 +111,6 @@ export function AboutDialog({
             </button>
             .
           </p>
-        )}
-
-        {ytdlp && (
-          <div className="rounded-md border border-border/70 bg-muted/30 px-3 py-2.5">
-            <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              Audio engine
-            </p>
-            <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
-              <dt className="text-muted-foreground">yt-dlp</dt>
-              <dd>{ytdlp.version ?? "Unavailable"}</dd>
-              <dt className="text-muted-foreground">Last update check</dt>
-              <dd>
-                {ytdlp.lastCheckAt
-                  ? new Date(ytdlp.lastCheckAt * 1000).toLocaleString()
-                  : "Never"}
-              </dd>
-              {ytdlp.lastResult && (
-                <>
-                  <dt className="text-muted-foreground">Result</dt>
-                  <dd
-                    className={
-                      ytdlp.lastResult.success ? undefined : "text-destructive"
-                    }
-                  >
-                    {ytdlp.lastResult.message}
-                  </dd>
-                </>
-              )}
-            </dl>
-          </div>
         )}
 
         <div>

--- a/src/components/layout/about-dialog.tsx
+++ b/src/components/layout/about-dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { getVersion } from "@tauri-apps/api/app";
+import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   Dialog,
@@ -19,6 +20,11 @@ import { DiscordIcon, GithubIcon } from "@/components/shared/brand-icons";
 
 const REPO_URL = "https://github.com/NUber-dev/YTubic";
 const DISCORD_URL = "https://discord.gg/4gccUpZyYH";
+
+type YtdlpDiagnostics = {
+  version: string | null;
+  lastCheckAt: number | null;
+};
 
 const CREDITS: { name: string; role: string; url: string }[] = [
   {
@@ -47,12 +53,16 @@ export function AboutDialog({
   onOpenChange: (v: boolean) => void;
 }) {
   const [version, setVersion] = useState<string>("");
+  const [ytdlp, setYtdlp] = useState<YtdlpDiagnostics | null>(null);
 
   useEffect(() => {
     if (!open) return;
     getVersion()
       .then(setVersion)
       .catch(() => setVersion(""));
+    invoke<YtdlpDiagnostics>("get_ytdlp_diagnostics")
+      .then(setYtdlp)
+      .catch(() => setYtdlp(null));
   }, [open]);
 
   const link = (url: string) => () => {
@@ -96,6 +106,17 @@ export function AboutDialog({
           affiliated with, endorsed by, or sponsored by Google or YouTube.
           "YouTube" and "YouTube Music" are trademarks of Google LLC.
         </p>
+
+        {ytdlp && (
+          <p className="text-xs text-muted-foreground">
+            Audio engine: yt-dlp {ytdlp.version ?? "unavailable"}. Last update
+            check:{" "}
+            {ytdlp.lastCheckAt
+              ? new Date(ytdlp.lastCheckAt * 1000).toLocaleString()
+              : "never"}
+            .
+          </p>
+        )}
 
         {IS_BETA_PLATFORM && (
           <p className="text-sm text-muted-foreground">

--- a/src/components/layout/about-dialog.tsx
+++ b/src/components/layout/about-dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { getVersion } from "@tauri-apps/api/app";
+import { invoke } from "@tauri-apps/api/core";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   Dialog,
@@ -19,6 +20,12 @@ import { DiscordIcon, GithubIcon } from "@/components/shared/brand-icons";
 
 const REPO_URL = "https://github.com/NUber-dev/YTubic";
 const DISCORD_URL = "https://discord.gg/4gccUpZyYH";
+
+type YtdlpDiagnostics = {
+  version: string | null;
+  lastCheckAt: number | null;
+  lastResult: { success: boolean; message: string } | null;
+};
 
 const CREDITS: { name: string; role: string; url: string }[] = [
   {
@@ -47,12 +54,16 @@ export function AboutDialog({
   onOpenChange: (v: boolean) => void;
 }) {
   const [version, setVersion] = useState<string>("");
+  const [ytdlp, setYtdlp] = useState<YtdlpDiagnostics | null>(null);
 
   useEffect(() => {
     if (!open) return;
     getVersion()
       .then(setVersion)
       .catch(() => setVersion(""));
+    invoke<YtdlpDiagnostics>("get_ytdlp_diagnostics")
+      .then(setYtdlp)
+      .catch(() => setYtdlp(null));
   }, [open]);
 
   const link = (url: string) => () => {
@@ -111,6 +122,36 @@ export function AboutDialog({
             </button>
             .
           </p>
+        )}
+
+        {ytdlp && (
+          <div className="rounded-md border border-border/70 bg-muted/30 px-3 py-2.5">
+            <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Audio engine
+            </p>
+            <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+              <dt className="text-muted-foreground">yt-dlp</dt>
+              <dd>{ytdlp.version ?? "Unavailable"}</dd>
+              <dt className="text-muted-foreground">Last update check</dt>
+              <dd>
+                {ytdlp.lastCheckAt
+                  ? new Date(ytdlp.lastCheckAt * 1000).toLocaleString()
+                  : "Never"}
+              </dd>
+              {ytdlp.lastResult && (
+                <>
+                  <dt className="text-muted-foreground">Result</dt>
+                  <dd
+                    className={
+                      ytdlp.lastResult.success ? undefined : "text-destructive"
+                    }
+                  >
+                    {ytdlp.lastResult.message}
+                  </dd>
+                </>
+              )}
+            </dl>
+          </div>
         )}
 
         <div>


### PR DESCRIPTION
## Motivation

YTubic silently manages its own yt-dlp copy, but About did not show which version was active or when it last checked for updates. That made playback regressions difficult to distinguish from an automatic binary update or a server-side YouTube change.

## Implementation

- Show the managed yt-dlp version and existing persistent update-check timestamp in About.
- Read diagnostics without making a network request or starting an update.
- Bound `yt-dlp --version` to 45 seconds and kill it on timeout, allowing for the documented cold macOS startup.
- Reuse the existing timestamp instead of adding another diagnostic sidecar.

## Testing

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` - 21 passed
- `pnpm test` - 229 passed
- `pnpm build`